### PR TITLE
Export api.HTTPError

### DIFF
--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -114,7 +114,7 @@ func newHTTPClient(opts *api.ClientOptions) http.Client {
 	return http.Client{Transport: transport, Timeout: opts.Timeout}
 }
 
-type httpError struct {
+type HttpError struct {
 	StatusCode  int
 	RequestURL  *url.URL
 	Message     string
@@ -129,7 +129,7 @@ type httpErrorItem struct {
 	Code     string
 }
 
-func (err httpError) Error() string {
+func (err HttpError) Error() string {
 	if msgs := strings.SplitN(err.Message, "\n", 2); len(msgs) > 1 {
 		return fmt.Sprintf("HTTP %d: %s (%s)\n%s", err.StatusCode, msgs[0], err.RequestURL, msgs[1])
 	} else if err.Message != "" {
@@ -139,7 +139,7 @@ func (err httpError) Error() string {
 }
 
 func handleHTTPError(resp *http.Response) error {
-	httpError := httpError{
+	httpError := HttpError{
 		StatusCode:  resp.StatusCode,
 		RequestURL:  resp.Request.URL,
 		OAuthScopes: resp.Header.Get("X-Oauth-Scopes"),

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -114,7 +114,7 @@ func newHTTPClient(opts *api.ClientOptions) http.Client {
 	return http.Client{Transport: transport, Timeout: opts.Timeout}
 }
 
-type HttpError struct {
+type HTTPError struct {
 	StatusCode  int
 	RequestURL  *url.URL
 	Message     string
@@ -129,7 +129,7 @@ type httpErrorItem struct {
 	Code     string
 }
 
-func (err HttpError) Error() string {
+func (err HTTPError) Error() string {
 	if msgs := strings.SplitN(err.Message, "\n", 2); len(msgs) > 1 {
 		return fmt.Sprintf("HTTP %d: %s (%s)\n%s", err.StatusCode, msgs[0], err.RequestURL, msgs[1])
 	} else if err.Message != "" {
@@ -139,7 +139,7 @@ func (err HttpError) Error() string {
 }
 
 func handleHTTPError(resp *http.Response) error {
-	httpError := HttpError{
+	httpError := HTTPError{
 		StatusCode:  resp.StatusCode,
 		RequestURL:  resp.Request.URL,
 		OAuthScopes: resp.Header.Get("X-Oauth-Scopes"),

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -1,0 +1,35 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// HTTPError represents an error response from the GitHub API.
+type HTTPError struct {
+	StatusCode  int
+	RequestURL  *url.URL
+	Message     string
+	OAuthScopes string
+	Errors      []HttpErrorItem
+}
+
+// HTTPErrorItem stores additional information about an error response
+// returned from the GitHub API.
+type HttpErrorItem struct {
+	Message  string
+	Resource string
+	Field    string
+	Code     string
+}
+
+// Allow HTTPError to satisfy error interface.
+func (err HTTPError) Error() string {
+	if msgs := strings.SplitN(err.Message, "\n", 2); len(msgs) > 1 {
+		return fmt.Sprintf("HTTP %d: %s (%s)\n%s", err.StatusCode, msgs[0], err.RequestURL, msgs[1])
+	} else if err.Message != "" {
+		return fmt.Sprintf("HTTP %d: %s (%s)", err.StatusCode, err.Message, err.RequestURL)
+	}
+	return fmt.Sprintf("HTTP %d (%s)", err.StatusCode, err.RequestURL)
+}


### PR DESCRIPTION
This is an attempt to fix the issue mentioned in #4. 

With the change in here, `api.HTTPError` would be exported and it would allow the caller to the REST API client to do things like 
```go
client, _ := gh.RESTClient(options)
err := client.Get(blah)
if err != nil {
    httpError := err.(*api.HTTPError)
    if httpError.StatusCode == 502 {
            ...retry
     }else{
            ...do something else
      }
}
```

Thanks for the 👀 💖 .