### PR TITLE
go get should not contain URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you'd like to use `go-gh` on systems without `gh` installed and configured, y
 
 ## Installation
 ```bash
-go get https://github.com/cli/go-gh
+go get github.com/cli/go-gh
 ```
 
 ## Usage


### PR DESCRIPTION
go get fails with example code:
```
go get https://github.com/cli/go-gh
go get: malformed module path "https:/github.com/cli/go-gh": invalid char ':'
```