### PR TITLE
Add support for GH_HOST and expose repository.Parse

### DIFF
--- a/internal/git/remote.go
+++ b/internal/git/remote.go
@@ -84,11 +84,11 @@ func parseRemotes(gitRemotes []string) RemoteSet {
 		urlStr := strings.TrimSpace(match[2])
 		urlType := strings.TrimSpace(match[3])
 
-		url, err := parseURL(urlStr)
+		url, err := ParseURL(urlStr)
 		if err != nil {
 			continue
 		}
-		host, owner, repo, _ := repoInfoFromURL(url)
+		host, owner, repo, _ := RepoInfoFromURL(url)
 
 		var rem *Remote
 		if len(remotes) > 0 {

--- a/internal/git/url.go
+++ b/internal/git/url.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 )
 
-func isURL(u string) bool {
+func IsURL(u string) bool {
 	return strings.HasPrefix(u, "git@") || isSupportedProtocol(u)
 }
 
@@ -15,6 +15,7 @@ func isSupportedProtocol(u string) bool {
 		strings.HasPrefix(u, "git+ssh:") ||
 		strings.HasPrefix(u, "git:") ||
 		strings.HasPrefix(u, "http:") ||
+		strings.HasPrefix(u, "git+https:") ||
 		strings.HasPrefix(u, "https:")
 }
 
@@ -25,8 +26,8 @@ func isPossibleProtocol(u string) bool {
 		strings.HasPrefix(u, "file:")
 }
 
-// Normalize git remote urls.
-func parseURL(rawURL string) (u *url.URL, err error) {
+// ParseURL normalizes git remote urls.
+func ParseURL(rawURL string) (u *url.URL, err error) {
 	if !isPossibleProtocol(rawURL) &&
 		strings.ContainsRune(rawURL, ':') &&
 		// Not a Windows path.
@@ -42,6 +43,10 @@ func parseURL(rawURL string) (u *url.URL, err error) {
 
 	if u.Scheme == "git+ssh" {
 		u.Scheme = "ssh"
+	}
+
+	if u.Scheme == "git+https" {
+		u.Scheme = "https"
 	}
 
 	if u.Scheme != "ssh" {
@@ -60,7 +65,7 @@ func parseURL(rawURL string) (u *url.URL, err error) {
 }
 
 // Extract GitHub repository information from a git remote URL.
-func repoInfoFromURL(u *url.URL) (host string, owner string, repo string, err error) {
+func RepoInfoFromURL(u *url.URL) (host string, owner string, name string, err error) {
 	if u.Hostname() == "" {
 		return "", "", "", fmt.Errorf("no hostname detected")
 	}

--- a/internal/git/url_test.go
+++ b/internal/git/url_test.go
@@ -34,6 +34,26 @@ func TestIsURL(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "git with extension",
+			url:  "git://example.com/owner/repo.git",
+			want: true,
+		},
+		{
+			name: "git+ssh",
+			url:  "git+ssh://git@example.com/owner/repo.git",
+			want: true,
+		},
+		{
+			name: "git+https",
+			url:  "git+https://example.com/owner/repo.git",
+			want: true,
+		},
+		{
+			name: "http",
+			url:  "http://example.com/owner/repo.git",
+			want: true,
+		},
+		{
 			name: "https",
 			url:  "https://example.com/owner/repo.git",
 			want: true,
@@ -46,7 +66,7 @@ func TestIsURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, isURL(tt.url))
+			assert.Equal(t, tt.want, IsURL(tt.url))
 		})
 	}
 }
@@ -126,6 +146,16 @@ func TestParseURL(t *testing.T) {
 			},
 		},
 		{
+			name: "git+https",
+			url:  "git+https://example.com/owner/repo.git",
+			want: url{
+				Scheme: "https",
+				User:   "",
+				Host:   "example.com",
+				Path:   "/owner/repo.git",
+			},
+		},
+		{
 			name: "scp-like",
 			url:  "git@example.com:owner/repo.git",
 			want: url{
@@ -178,7 +208,7 @@ func TestParseURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			u, err := parseURL(tt.url)
+			u, err := ParseURL(tt.url)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -275,7 +305,7 @@ func TestRepoInfoFromURL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			u, err := url.Parse(tt.input)
 			assert.NoError(t, err)
-			host, owner, repo, err := repoInfoFromURL(u)
+			host, owner, repo, err := RepoInfoFromURL(u)
 			if tt.wantErr {
 				assert.EqualError(t, err, tt.wantErrMsg)
 				return

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1,0 +1,24 @@
+package repository
+
+func New(host, owner, name string) repo {
+	return repo{host: host, owner: owner, name: name}
+}
+
+// Implements repository.Repository interface.
+type repo struct {
+	host  string
+	owner string
+	name  string
+}
+
+func (r repo) Host() string {
+	return r.host
+}
+
+func (r repo) Owner() string {
+	return r.owner
+}
+
+func (r repo) Name() string {
+	return r.name
+}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,0 +1,55 @@
+package repository
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/cli/go-gh/internal/git"
+	irepo "github.com/cli/go-gh/internal/repository"
+)
+
+// Repository is the interface that wraps repository information methods.
+type Repository interface {
+	Host() string
+	Name() string
+	Owner() string
+}
+
+// Parse extracts the repository information from the following
+// string formats: "OWNER/REPO", "HOST/OWNER/REPO", and a full URL.
+func Parse(s string) (Repository, error) {
+	if git.IsURL(s) {
+		u, err := git.ParseURL(s)
+		if err != nil {
+			return nil, err
+		}
+
+		host, owner, name, err := git.RepoInfoFromURL(u)
+		if err != nil {
+			return nil, err
+		}
+
+		return irepo.New(host, owner, name), nil
+	}
+
+	parts := strings.SplitN(s, "/", 4)
+	for _, p := range parts {
+		if len(p) == 0 {
+			return nil, fmt.Errorf(`expected the "[HOST/]OWNER/REPO" format, got %q`, s)
+		}
+	}
+
+	switch len(parts) {
+	case 3:
+		return irepo.New(parts[0], parts[1], parts[2]), nil
+	case 2:
+		host := os.Getenv("GH_HOST")
+		if host == "" {
+			host = "github.com"
+		}
+		return irepo.New(host, parts[0], parts[1]), nil
+	default:
+		return nil, fmt.Errorf(`expected the "[HOST/]OWNER/REPO" format, got %q`, s)
+	}
+}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -1,3 +1,5 @@
+// Package repository is a set of types and functions for modeling and
+// interacting with GitHub repositories.
 package repository
 
 import (

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -1,0 +1,98 @@
+package repository
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		hostOverride string
+		wantOwner    string
+		wantName     string
+		wantHost     string
+		wantErr      string
+	}{
+		{
+			name:      "OWNER/REPO combo",
+			input:     "OWNER/REPO",
+			wantHost:  "github.com",
+			wantOwner: "OWNER",
+			wantName:  "REPO",
+		},
+		{
+			name:    "too few elements",
+			input:   "OWNER",
+			wantErr: `expected the "[HOST/]OWNER/REPO" format, got "OWNER"`,
+		},
+		{
+			name:    "too many elements",
+			input:   "a/b/c/d",
+			wantErr: `expected the "[HOST/]OWNER/REPO" format, got "a/b/c/d"`,
+		},
+		{
+			name:    "blank value",
+			input:   "a/",
+			wantErr: `expected the "[HOST/]OWNER/REPO" format, got "a/"`,
+		},
+		{
+			name:      "with hostname",
+			input:     "example.org/OWNER/REPO",
+			wantHost:  "example.org",
+			wantOwner: "OWNER",
+			wantName:  "REPO",
+		},
+		{
+			name:      "full URL",
+			input:     "https://example.org/OWNER/REPO.git",
+			wantHost:  "example.org",
+			wantOwner: "OWNER",
+			wantName:  "REPO",
+		},
+		{
+			name:      "SSH URL",
+			input:     "git@example.org:OWNER/REPO.git",
+			wantHost:  "example.org",
+			wantOwner: "OWNER",
+			wantName:  "REPO",
+		},
+		{
+			name:         "OWNER/REPO with default host override",
+			input:        "OWNER/REPO",
+			hostOverride: "override.com",
+			wantHost:     "override.com",
+			wantOwner:    "OWNER",
+			wantName:     "REPO",
+		},
+		{
+			name:         "HOST/OWNER/REPO with default host override",
+			input:        "example.com/OWNER/REPO",
+			hostOverride: "override.com",
+			wantHost:     "example.com",
+			wantOwner:    "OWNER",
+			wantName:     "REPO",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.hostOverride != "" {
+				old := os.Getenv("GH_HOST")
+				os.Setenv("GH_HOST", tt.hostOverride)
+				defer os.Setenv("GH_HOST", old)
+			}
+			r, err := Parse(tt.input)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantHost, r.Host())
+			assert.Equal(t, tt.wantOwner, r.Owner())
+			assert.Equal(t, tt.wantName, r.Name())
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for the `GH_HOME` environment variable to the `CurrentRepository` function. To support this new functionality I added a new function `Parse` to the new `repository` package. The `Parse` function is exported as the operation of parsing a string into its repository information seems like a useful utility for extension authors to have.   
 
Closes https://github.com/cli/go-gh/issues/8