### PR TITLE
Fix regression caused by resolveOptions

### DIFF
--- a/gh.go
+++ b/gh.go
@@ -64,8 +64,7 @@ func RESTClient(opts *api.ClientOptions) (api.RESTClient, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	err = resolveOptions(&opts, cfg)
+	err = resolveOptions(opts, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -83,8 +82,7 @@ func GQLClient(opts *api.ClientOptions) (api.GQLClient, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	err = resolveOptions(&opts, cfg)
+	err = resolveOptions(opts, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -102,13 +100,11 @@ func HTTPClient(opts *api.ClientOptions) (*http.Client, error) {
 	if opts == nil {
 		opts = &api.ClientOptions{}
 	}
-
 	cfg, err := config.Load()
 	if err != nil {
 		return nil, err
 	}
-
-	err = resolveOptions(&opts, cfg)
+	err = resolveOptions(opts, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -151,11 +147,9 @@ func CurrentRepository() (repo.Repository, error) {
 	return irepo.New(r.Host, r.Owner, r.Repo), nil
 }
 
-func resolveOptions(clientOptions **api.ClientOptions, cfg config.Config) error {
-	var opts = *clientOptions
+func resolveOptions(opts *api.ClientOptions, cfg config.Config) error {
 	var token string
 	var err error
-
 	if opts.Host == "" {
 		opts.Host = cfg.Host()
 	}
@@ -166,7 +160,6 @@ func resolveOptions(clientOptions **api.ClientOptions, cfg config.Config) error 
 		}
 		opts.AuthToken = token
 	}
-	*clientOptions = opts
 	return nil
 }
 

--- a/gh.go
+++ b/gh.go
@@ -60,8 +60,12 @@ func RESTClient(opts *api.ClientOptions) (api.RESTClient, error) {
 	if opts == nil {
 		opts = &api.ClientOptions{}
 	}
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
 
-	err := resolveOptions(&opts)
+	err = resolveOptions(&opts, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -75,8 +79,12 @@ func GQLClient(opts *api.ClientOptions) (api.GQLClient, error) {
 	if opts == nil {
 		opts = &api.ClientOptions{}
 	}
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
 
-	err := resolveOptions(&opts)
+	err = resolveOptions(&opts, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +103,12 @@ func HTTPClient(opts *api.ClientOptions) (*http.Client, error) {
 		opts = &api.ClientOptions{}
 	}
 
-	err := resolveOptions(&opts)
+	cfg, err := config.Load()
+	if err != nil {
+		return nil, err
+	}
+
+	err = resolveOptions(&opts, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -138,17 +151,11 @@ func CurrentRepository() (repo.Repository, error) {
 	return irepo.New(r.Host, r.Owner, r.Repo), nil
 }
 
-func resolveOptions(clientOptions **api.ClientOptions) error {
+func resolveOptions(clientOptions **api.ClientOptions, cfg config.Config) error {
 	var opts = *clientOptions
-	var cfg config.Config
 	var token string
 	var err error
-	if opts.Host == "" || opts.AuthToken == "" {
-		cfg, err = config.Load()
-		if err != nil {
-			return err
-		}
-	}
+
 	if opts.Host == "" {
 		opts.Host = cfg.Host()
 	}

--- a/gh.go
+++ b/gh.go
@@ -57,7 +57,7 @@ func run(path string, env []string, args ...string) (stdOut, stdErr bytes.Buffer
 // As part of the configuration a hostname, auth token, and default set of headers are resolved
 // from the gh environment configuration. These behaviors can be overridden using the opts argument.
 func RESTClient(opts *api.ClientOptions) (api.RESTClient, error) {
-	err := resolveOptions(opts)
+	err := resolveOptions(&opts)
 	if err != nil {
 		return nil, err
 	}
@@ -68,7 +68,7 @@ func RESTClient(opts *api.ClientOptions) (api.RESTClient, error) {
 // As part of the configuration a hostname, auth token, and default set of headers are resolved
 // from the gh environment configuration. These behaviors can be overridden using the opts argument.
 func GQLClient(opts *api.ClientOptions) (api.GQLClient, error) {
-	err := resolveOptions(opts)
+	err := resolveOptions(&opts)
 	if err != nil {
 		return nil, err
 	}
@@ -83,7 +83,7 @@ func GQLClient(opts *api.ClientOptions) (api.GQLClient, error) {
 // host, the auth token will not be added to the headers. This is to protect against the case where tokens
 // could be sent to an arbitrary host.
 func HTTPClient(opts *api.ClientOptions) (*http.Client, error) {
-	err := resolveOptions(opts)
+	err := resolveOptions(&opts)
 	if err != nil {
 		return nil, err
 	}
@@ -126,7 +126,8 @@ func CurrentRepository() (repo.Repository, error) {
 	return irepo.New(r.Host, r.Owner, r.Repo), nil
 }
 
-func resolveOptions(opts *api.ClientOptions) error {
+func resolveOptions(clientOptions **api.ClientOptions) error {
+	var opts = *clientOptions
 	var cfg config.Config
 	var token string
 	var err error
@@ -149,6 +150,7 @@ func resolveOptions(opts *api.ClientOptions) error {
 		}
 		opts.AuthToken = token
 	}
+	*clientOptions = opts
 	return nil
 }
 

--- a/gh.go
+++ b/gh.go
@@ -57,6 +57,10 @@ func run(path string, env []string, args ...string) (stdOut, stdErr bytes.Buffer
 // As part of the configuration a hostname, auth token, and default set of headers are resolved
 // from the gh environment configuration. These behaviors can be overridden using the opts argument.
 func RESTClient(opts *api.ClientOptions) (api.RESTClient, error) {
+	if opts == nil {
+		opts = &api.ClientOptions{}
+	}
+
 	err := resolveOptions(&opts)
 	if err != nil {
 		return nil, err
@@ -68,6 +72,10 @@ func RESTClient(opts *api.ClientOptions) (api.RESTClient, error) {
 // As part of the configuration a hostname, auth token, and default set of headers are resolved
 // from the gh environment configuration. These behaviors can be overridden using the opts argument.
 func GQLClient(opts *api.ClientOptions) (api.GQLClient, error) {
+	if opts == nil {
+		opts = &api.ClientOptions{}
+	}
+
 	err := resolveOptions(&opts)
 	if err != nil {
 		return nil, err
@@ -83,6 +91,10 @@ func GQLClient(opts *api.ClientOptions) (api.GQLClient, error) {
 // host, the auth token will not be added to the headers. This is to protect against the case where tokens
 // could be sent to an arbitrary host.
 func HTTPClient(opts *api.ClientOptions) (*http.Client, error) {
+	if opts == nil {
+		opts = &api.ClientOptions{}
+	}
+
 	err := resolveOptions(&opts)
 	if err != nil {
 		return nil, err
@@ -131,9 +143,6 @@ func resolveOptions(clientOptions **api.ClientOptions) error {
 	var cfg config.Config
 	var token string
 	var err error
-	if opts == nil {
-		opts = &api.ClientOptions{}
-	}
 	if opts.Host == "" || opts.AuthToken == "" {
 		cfg, err = config.Load()
 		if err != nil {

--- a/gh_test.go
+++ b/gh_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cli/go-gh/internal/config"
 	"github.com/cli/go-gh/internal/httpmock"
 	"github.com/cli/go-gh/pkg/api"
 	"github.com/stretchr/testify/assert"
@@ -127,4 +128,54 @@ func TestHTTPClient(t *testing.T) {
 	assert.Equal(t, 200, res.StatusCode)
 	assert.Equal(t, "api.github.com", http.Requests[0].URL.Hostname())
 	assert.Equal(t, "token GH_TOKEN", http.Requests[0].Header.Get("Authorization"))
+}
+
+func TestResolveOptions(t *testing.T) {
+	cfg := testConfig()
+
+	tests := []struct {
+		name          string
+		opts          *api.ClientOptions
+		wantAuthToken string
+		wantHost      string
+	}{
+		{
+			name: "honors consumer provided ClientOptions",
+			opts: &api.ClientOptions{
+				Host:      "test.com",
+				AuthToken: "token_from_opts",
+			},
+			wantAuthToken: "token_from_opts",
+			wantHost:      "test.com",
+		},
+		{
+			name:          "uses config values if there are no consumer provided ClientOptions",
+			opts:          &api.ClientOptions{},
+			wantAuthToken: "token",
+			wantHost:      "github.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			err := resolveOptions(&tt.opts, cfg)
+
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantHost, tt.opts.Host)
+			assert.Equal(t, tt.wantAuthToken, tt.opts.AuthToken)
+		})
+	}
+}
+
+func testConfig() config.Config {
+	var data = `
+hosts:
+  github.com:
+    user: user1
+    oauth_token: token
+    git_protocol: ssh
+`
+	cfg, _ := config.FromString(data)
+	return cfg
 }

--- a/gh_test.go
+++ b/gh_test.go
@@ -158,9 +158,7 @@ func TestResolveOptions(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-
-			err := resolveOptions(&tt.opts, cfg)
-
+			err := resolveOptions(tt.opts, cfg)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.wantHost, tt.opts.Host)
 			assert.Equal(t, tt.wantAuthToken, tt.opts.AuthToken)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -116,7 +116,7 @@ func normalizeHostname(host string) string {
 	return hostname
 }
 
-func fromString(str string) (Config, error) {
+func FromString(str string) (Config, error) {
 	root, err := parseData([]byte(str))
 	if err != nil {
 		return nil, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -659,7 +659,7 @@ hosts:
     oauth_token: yyyyyyyyyyyyyyyyyyyy
     git_protocol: https
 `
-	cfg, _ := fromString(data)
+	cfg, _ := FromString(data)
 	return cfg
 }
 
@@ -675,11 +675,11 @@ hosts:
     oauth_token: yyyyyyyyyyyyyyyyyyyy
     git_protocol: https
 `
-	cfg, _ := fromString(data)
+	cfg, _ := FromString(data)
 	return cfg
 }
 
 func testLoadedNoHostConfig() Config {
-	cfg, _ := fromString(testGlobalConfig())
+	cfg, _ := FromString(testGlobalConfig())
 	return cfg
 }


### PR DESCRIPTION
If opts was nil, resolveOptions would only update the local copy of opts. The pointer was never being updated and was therefore nil when passed to the New*Client methods.

Closes #17 