### PR TITLE
Export GraphQL error types

### DIFF
--- a/internal/api/gql_client.go
+++ b/internal/api/gql_client.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 
 	"github.com/cli/go-gh/pkg/api"
 	graphql "github.com/cli/shurcooL-graphql"
@@ -75,7 +74,7 @@ func (c gqlClient) Do(query string, variables map[string]interface{}, response i
 	}
 
 	if len(gr.Errors) > 0 {
-		return &gqlErrorResponse{Errors: gr.Errors}
+		return &api.GQLError{Errors: gr.Errors}
 	}
 
 	return nil
@@ -97,22 +96,5 @@ func (c gqlClient) Query(name string, q interface{}, variables map[string]interf
 
 type gqlResponse struct {
 	Data   interface{}
-	Errors []gqlError
-}
-
-type gqlError struct {
-	Type    string
-	Message string
-}
-
-type gqlErrorResponse struct {
-	Errors []gqlError
-}
-
-func (gr gqlErrorResponse) Error() string {
-	errorMessages := make([]string, 0, len(gr.Errors))
-	for _, e := range gr.Errors {
-		errorMessages = append(errorMessages, e.Message)
-	}
-	return fmt.Sprintf("GQL error: %s", strings.Join(errorMessages, "\n"))
+	Errors []api.GQLErrorItem
 }

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -149,9 +149,9 @@ func handleHTTPError(resp *http.Response) error {
 			var errString string
 			_ = json.Unmarshal(raw, &errString)
 			messages = append(messages, errString)
-			httpError.Errors = append(httpError.Errors, api.HttpErrorItem{Message: errString})
+			httpError.Errors = append(httpError.Errors, api.HTTPErrorItem{Message: errString})
 		case '{':
-			var errInfo api.HttpErrorItem
+			var errInfo api.HTTPErrorItem
 			_ = json.Unmarshal(raw, &errInfo)
 			msg := errInfo.Message
 			if errInfo.Code != "" && errInfo.Code != "custom" {

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -2,8 +2,10 @@
 package api
 
 import (
+	"fmt"
 	"io"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -96,4 +98,24 @@ type GQLClient interface {
 	// The query argument should be a pointer to struct that corresponds
 	// to the GitHub GraphQL schema.
 	Query(name string, query interface{}, variables map[string]interface{}) error
+}
+
+// GQLError contains GQLErrors from a GraphQ request.
+type GQLError struct {
+	Errors []GQLErrorItem
+}
+
+// GQLErrorItem contains error information from a GraphQL request.
+type GQLErrorItem struct {
+	Type    string
+	Message string
+}
+
+// Error formats all GQLError messages.
+func (gr GQLError) Error() string {
+	errorMessages := make([]string, 0, len(gr.Errors))
+	for _, e := range gr.Errors {
+		errorMessages = append(errorMessages, e.Message)
+	}
+	return fmt.Sprintf("GQL error: %s", strings.Join(errorMessages, "\n"))
 }

--- a/pkg/api/client.go
+++ b/pkg/api/client.go
@@ -100,7 +100,7 @@ type GQLClient interface {
 	Query(name string, query interface{}, variables map[string]interface{}) error
 }
 
-// GQLError contains GQLErrors from a GraphQ request.
+// GQLError contains GQLErrors from a GraphQL request.
 type GQLError struct {
 	Errors []GQLErrorItem
 }

--- a/pkg/api/http.go
+++ b/pkg/api/http.go
@@ -12,12 +12,12 @@ type HTTPError struct {
 	RequestURL  *url.URL
 	Message     string
 	OAuthScopes string
-	Errors      []HttpErrorItem
+	Errors      []HTTPErrorItem
 }
 
 // HTTPErrorItem stores additional information about an error response
 // returned from the GitHub API.
-type HttpErrorItem struct {
+type HTTPErrorItem struct {
 	Message  string
 	Resource string
 	Field    string


### PR DESCRIPTION
Similar to `HTTPError` and `HTTPErrorItem` already (which was actually `HttpErrorItem`), export `GQLError` (was `GQLErrorREsponse`) and `GQLErrorItem` (was `GQLError`). This makes it possible for callers to check the errors and react accordingly, as in cli/cli#5588 where certain GraphQL errors could be filtered out.