### PR TITLE
Add default host as known host when environment auth token exists

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,6 +72,9 @@ func (c config) Hosts() []string {
 	if host := os.Getenv(ghHost); host != "" {
 		hosts.Add(host)
 	}
+	if token, _ := c.AuthToken(defaultHost); token != "" {
+		hosts.Add(defaultHost)
+	}
 	entries := c.hosts.keys()
 	hosts.AddValues(entries)
 	return hosts.ToSlice()

--- a/internal/set/string_set.go
+++ b/internal/set/string_set.go
@@ -10,6 +10,7 @@ type stringSet struct {
 func NewStringSet() *stringSet {
 	s := &stringSet{}
 	s.m = make(map[string]struct{})
+	s.v = []string{}
 	return s
 }
 


### PR DESCRIPTION
This PR adds functionality to `config.Hosts()` to include the default host if there is an environment authentication token that applies to the default host. Additionally it adds tests for `config.Hosts()` that did not exist before.

Fixes https://github.com/cli/go-gh/issues/34