### PR TITLE
Fix up bad merge where error headers got lost

### DIFF
--- a/internal/api/rest_client.go
+++ b/internal/api/rest_client.go
@@ -38,10 +38,9 @@ func (c restClient) Request(method string, path string, body io.Reader) (*http.R
 	success := resp.StatusCode >= 200 && resp.StatusCode < 300
 	if !success {
 		err = api.HTTPError{
-			StatusCode:          resp.StatusCode,
-			RequestURL:          resp.Request.URL,
-			AcceptedOAuthScopes: resp.Header.Get("X-Accepted-Oauth-Scopes"),
-			OAuthScopes:         resp.Header.Get("X-Oauth-Scopes"),
+			Headers:    resp.Header,
+			RequestURL: resp.Request.URL,
+			StatusCode: resp.StatusCode,
 		}
 	}
 

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -18,12 +18,11 @@ var jsonTypeRE = regexp.MustCompile(`[/+]json($|;)`)
 
 // HTTPError represents an error response from the GitHub API.
 type HTTPError struct {
-	AcceptedOAuthScopes string
-	Errors              []HTTPErrorItem
-	Message             string
-	OAuthScopes         string
-	RequestURL          *url.URL
-	StatusCode          int
+	Errors     []HTTPErrorItem
+	Headers    http.Header
+	Message    string
+	RequestURL *url.URL
+	StatusCode int
 }
 
 // HTTPErrorItem stores additional information about an error response
@@ -103,10 +102,9 @@ func matchPath(p, expect string) bool {
 // HandleHTTPError parses a http.Response into a HTTPError.
 func HandleHTTPError(resp *http.Response) error {
 	httpError := HTTPError{
-		StatusCode:          resp.StatusCode,
-		RequestURL:          resp.Request.URL,
-		AcceptedOAuthScopes: resp.Header.Get("X-Accepted-Oauth-Scopes"),
-		OAuthScopes:         resp.Header.Get("X-Oauth-Scopes"),
+		Headers:    resp.Header,
+		RequestURL: resp.Request.URL,
+		StatusCode: resp.StatusCode,
 	}
 
 	if !jsonTypeRE.MatchString(resp.Header.Get(contentType)) {


### PR DESCRIPTION
Not sure how but the change of `AcceptedOAuthScopes` and `OAuthScopes` to `Headers` got lost, so this is just replacing it.