### PR TITLE
Turn config into a singleton

### DIFF
--- a/internal/yamlmap/yaml_map.go
+++ b/internal/yamlmap/yaml_map.go
@@ -147,6 +147,10 @@ func (m *Map) SetEntry(key string, value *Map) {
 // has no impact for our purposes.
 func (m *Map) SetModified() {
 	// Can not mark a non-mapping node as modified
+	if m.Node.Kind != yaml.MappingNode && m.Node.Tag == "!!null" {
+		m.Node.Kind = yaml.MappingNode
+		m.Node.Tag = "!!map"
+	}
 	if m.Node.Kind == yaml.MappingNode {
 		m.Node.Value = modified
 	}

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -4,6 +4,7 @@ package auth
 
 import (
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/cli/go-gh/internal/set"
@@ -11,6 +12,7 @@ import (
 )
 
 const (
+	codespaces            = "CODESPACES"
 	defaultSource         = "default"
 	ghEnterpriseToken     = "GH_ENTERPRISE_TOKEN"
 	ghHost                = "GH_HOST"
@@ -39,6 +41,11 @@ func tokenForHost(cfg *config.Config, host string) (string, string) {
 		}
 		if token := os.Getenv(githubEnterpriseToken); token != "" {
 			return token, githubEnterpriseToken
+		}
+		if isCodespaces, _ := strconv.ParseBool(os.Getenv(codespaces)); isCodespaces {
+			if token := os.Getenv(githubToken); token != "" {
+				return token, githubToken
+			}
 		}
 		if cfg != nil {
 			token, _ := cfg.Get([]string{hostsKey, host, oauthToken})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -205,11 +205,11 @@ func load(generalFilePath, hostsFilePath string) (*Config, error) {
 }
 
 func generalConfigFile() string {
-	return filepath.Join(configDir(), "config.yml")
+	return filepath.Join(ConfigDir(), "config.yml")
 }
 
 func hostsConfigFile() string {
-	return filepath.Join(configDir(), "hosts.yml")
+	return filepath.Join(ConfigDir(), "hosts.yml")
 }
 
 func mapFromFile(filename string) (*yamlmap.Map, error) {
@@ -225,7 +225,7 @@ func mapFromString(str string) (*yamlmap.Map, error) {
 }
 
 // Config path precedence: GH_CONFIG_DIR, XDG_CONFIG_HOME, AppData (windows only), HOME.
-func configDir() string {
+func ConfigDir() string {
 	var path string
 	if a := os.Getenv(ghConfigDir); a != "" {
 		path = a
@@ -241,7 +241,7 @@ func configDir() string {
 }
 
 // State path precedence: XDG_STATE_HOME, LocalAppData (windows only), HOME.
-func stateDir() string {
+func StateDir() string {
 	var path string
 	if a := os.Getenv(xdgStateHome); a != "" {
 		path = filepath.Join(a, "gh")
@@ -255,7 +255,7 @@ func stateDir() string {
 }
 
 // Data path precedence: XDG_DATA_HOME, LocalAppData (windows only), HOME.
-func dataDir() string {
+func DataDir() string {
 	var path string
 	if a := os.Getenv(xdgDataHome); a != "" {
 		path = filepath.Join(a, "gh")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -380,7 +380,7 @@ func TestWrite(t *testing.T) {
 			cfg := tt.createConfig()
 			err := Write(cfg)
 			assert.NoError(t, err)
-			loadedCfg, err := Read()
+			loadedCfg, err := load(generalConfigFile(), hostsConfigFile())
 			assert.NoError(t, err)
 			wantCfg := cfg
 			if tt.wantConfig != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -92,7 +92,7 @@ func TestConfigDir(t *testing.T) {
 					defer os.Setenv(k, old)
 				}
 			}
-			assert.Equal(t, tt.output, configDir())
+			assert.Equal(t, tt.output, ConfigDir())
 		})
 	}
 }
@@ -156,7 +156,7 @@ func TestStateDir(t *testing.T) {
 					defer os.Setenv(k, old)
 				}
 			}
-			assert.Equal(t, tt.output, stateDir())
+			assert.Equal(t, tt.output, StateDir())
 		})
 	}
 }
@@ -220,7 +220,7 @@ func TestDataDir(t *testing.T) {
 					defer os.Setenv(k, old)
 				}
 			}
-			assert.Equal(t, tt.output, dataDir())
+			assert.Equal(t, tt.output, DataDir())
 		})
 	}
 }


### PR DESCRIPTION
This is a follow up PR to https://github.com/cli/go-gh/pull/44. 

Changes in this PR:
- export `ConfigDir`, `StateDir`, `DataDir`
- add Codespaces support in `tokenForHost`
- When using `Read` the loaded config will be cached in a global singleton variable so that subsequent calls to `Read` will not need to access the filesystem again.

cc https://github.com/cli/cli/issues/5560