### PR TITLE
Add support for localhost

### DIFF
--- a/internal/api/gql_client_test.go
+++ b/internal/api/gql_client_test.go
@@ -167,3 +167,34 @@ func TestGQLClientDoWithContext(t *testing.T) {
 		})
 	}
 }
+
+func TestGQLEndpoint(t *testing.T) {
+	tests := []struct {
+		name         string
+		host         string
+		wantEndpoint string
+	}{
+		{
+			name:         "github",
+			host:         "github.com",
+			wantEndpoint: "https://api.github.com/graphql",
+		},
+		{
+			name:         "localhost",
+			host:         "github.localhost",
+			wantEndpoint: "http://api.github.localhost/graphql",
+		},
+		{
+			name:         "enterprise",
+			host:         "enterprise.com",
+			wantEndpoint: "https://enterprise.com/api/graphql",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint := gqlEndpoint(tt.host)
+			assert.Equal(t, tt.wantEndpoint, endpoint)
+		})
+	}
+}

--- a/internal/api/http.go
+++ b/internal/api/http.go
@@ -19,8 +19,9 @@ const (
 	accept          = "Accept"
 	authorization   = "Authorization"
 	contentType     = "Content-Type"
-	defaultHostname = "github.com"
+	github          = "github.com"
 	jsonContentType = "application/json; charset=utf-8"
+	localhost       = "github.localhost"
 	modulePath      = "github.com/cli/go-gh"
 	timeZone        = "Time-Zone"
 	userAgent       = "User-Agent"
@@ -127,7 +128,18 @@ func isSameDomain(requestHost, domain string) bool {
 }
 
 func isEnterprise(host string) bool {
-	return host != defaultHostname
+	return host != github && host != localhost
+}
+
+func normalizeHostname(hostname string) string {
+	hostname = strings.ToLower(hostname)
+	if strings.HasSuffix(hostname, "."+github) {
+		return github
+	}
+	if strings.HasSuffix(hostname, "."+localhost) {
+		return localhost
+	}
+	return hostname
 }
 
 type headerRoundTripper struct {

--- a/internal/api/http_test.go
+++ b/internal/api/http_test.go
@@ -121,6 +121,73 @@ func TestNewHTTPClient(t *testing.T) {
 	}
 }
 
+func TestIsEnterprise(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		wantOut bool
+	}{
+		{
+			name:    "github",
+			host:    "github.com",
+			wantOut: false,
+		},
+		{
+			name:    "localhost",
+			host:    "github.localhost",
+			wantOut: false,
+		},
+		{
+			name:    "enterprise",
+			host:    "mygithub.com",
+			wantOut: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := isEnterprise(tt.host)
+			assert.Equal(t, tt.wantOut, out)
+		})
+	}
+}
+
+func TestNormalizeHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		wantHost string
+	}{
+		{
+			name:     "github domain",
+			host:     "test.github.com",
+			wantHost: "github.com",
+		},
+		{
+			name:     "capitalized",
+			host:     "GitHub.com",
+			wantHost: "github.com",
+		},
+		{
+			name:     "localhost domain",
+			host:     "test.github.localhost",
+			wantHost: "github.localhost",
+		},
+		{
+			name:     "enterprise domain",
+			host:     "mygithub.com",
+			wantHost: "mygithub.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized := normalizeHostname(tt.host)
+			assert.Equal(t, tt.wantHost, normalized)
+		})
+	}
+}
+
 type tripper struct {
 	roundTrip func(*http.Request) (*http.Response, error)
 }

--- a/internal/api/rest_client.go
+++ b/internal/api/rest_client.go
@@ -119,8 +119,12 @@ func restURL(hostname string, pathOrURL string) string {
 }
 
 func restPrefix(hostname string) string {
+	hostname = normalizeHostname(hostname)
 	if isEnterprise(hostname) {
 		return fmt.Sprintf("https://%s/api/v3/", hostname)
 	}
-	return "https://api.github.com/"
+	if strings.EqualFold(hostname, localhost) {
+		return fmt.Sprintf("http://api.%s/", hostname)
+	}
+	return fmt.Sprintf("https://api.%s/", hostname)
 }

--- a/internal/api/rest_client_test.go
+++ b/internal/api/rest_client_test.go
@@ -390,6 +390,37 @@ func TestRESTClientRequestWithContext(t *testing.T) {
 	}
 }
 
+func TestRestPrefix(t *testing.T) {
+	tests := []struct {
+		name         string
+		host         string
+		wantEndpoint string
+	}{
+		{
+			name:         "github",
+			host:         "github.com",
+			wantEndpoint: "https://api.github.com/",
+		},
+		{
+			name:         "localhost",
+			host:         "github.localhost",
+			wantEndpoint: "http://api.github.localhost/",
+		},
+		{
+			name:         "enterprise",
+			host:         "enterprise.com",
+			wantEndpoint: "https://enterprise.com/api/v3/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			endpoint := restPrefix(tt.host)
+			assert.Equal(t, tt.wantEndpoint, endpoint)
+		})
+	}
+}
+
 func printPendingMocks(mocks []gock.Mock) string {
 	paths := []string{}
 	for _, mock := range mocks {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -21,6 +21,7 @@ const (
 	githubEnterpriseToken = "GITHUB_ENTERPRISE_TOKEN"
 	githubToken           = "GITHUB_TOKEN"
 	hostsKey              = "hosts"
+	localhost             = "github.localhost"
 	oauthToken            = "oauth_token"
 )
 
@@ -114,13 +115,16 @@ func defaultHost(cfg *config.Config) (string, string) {
 }
 
 func isEnterprise(host string) bool {
-	return host != github
+	return host != github && host != localhost
 }
 
 func normalizeHostname(host string) string {
 	hostname := strings.ToLower(host)
 	if strings.HasSuffix(hostname, "."+github) {
 		return github
+	}
+	if strings.HasSuffix(hostname, "."+localhost) {
+		return localhost
 	}
 	return hostname
 }

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -223,6 +223,73 @@ func TestKnownHosts(t *testing.T) {
 	}
 }
 
+func TestIsEnterprise(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		wantOut bool
+	}{
+		{
+			name:    "github",
+			host:    "github.com",
+			wantOut: false,
+		},
+		{
+			name:    "localhost",
+			host:    "github.localhost",
+			wantOut: false,
+		},
+		{
+			name:    "enterprise",
+			host:    "mygithub.com",
+			wantOut: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := isEnterprise(tt.host)
+			assert.Equal(t, tt.wantOut, out)
+		})
+	}
+}
+
+func TestNormalizeHostname(t *testing.T) {
+	tests := []struct {
+		name     string
+		host     string
+		wantHost string
+	}{
+		{
+			name:     "github domain",
+			host:     "test.github.com",
+			wantHost: "github.com",
+		},
+		{
+			name:     "capitalized",
+			host:     "GitHub.com",
+			wantHost: "github.com",
+		},
+		{
+			name:     "localhost domain",
+			host:     "test.github.localhost",
+			wantHost: "github.localhost",
+		},
+		{
+			name:     "enterprise domain",
+			host:     "mygithub.com",
+			wantHost: "mygithub.com",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized := normalizeHostname(tt.host)
+			assert.Equal(t, tt.wantHost, normalized)
+		})
+	}
+}
+
 func testNoHostsConfig() *config.Config {
 	var data = ``
 	return config.ReadFromString(data)


### PR DESCRIPTION
This PR adds support for `github.localhost` host for the `api` and `auth` packages. The logic now reflects the same logic used in `cli`.

Closes https://github.com/cli/go-gh/issues/48