### PR TITLE
Pass correct host to gql client

### DIFF
--- a/internal/api/gql_client.go
+++ b/internal/api/gql_client.go
@@ -23,10 +23,10 @@ type gqlClient struct {
 
 func NewGQLClient(host string, opts *api.ClientOptions) api.GQLClient {
 	httpClient := NewHTTPClient(opts)
-
+	endpoint := gqlEndpoint(host)
 	return gqlClient{
-		client:     graphql.NewClient(host, &httpClient),
-		host:       gqlEndpoint(host),
+		client:     graphql.NewClient(endpoint, &httpClient),
+		host:       endpoint,
 		httpClient: &httpClient,
 	}
 }


### PR DESCRIPTION
Fix small regression from localhost implementation where the GQL endpoint was not being passed to the GQL client correctly. 