### PR TITLE
Do not return an error when blank config files are read

### DIFF
--- a/internal/yamlmap/yaml_map.go
+++ b/internal/yamlmap/yaml_map.go
@@ -41,7 +41,10 @@ func Unmarshal(data []byte) (*Map, error) {
 	if err != nil {
 		return nil, ErrInvalidYaml
 	}
-	if len(root.Content) == 0 || root.Content[0].Kind != yaml.MappingNode {
+	if len(root.Content) == 0 {
+		return MapValue(), nil
+	}
+	if root.Content[0].Kind != yaml.MappingNode {
 		return nil, ErrInvalidFormat
 	}
 	return &Map{root.Content[0]}, nil

--- a/internal/yamlmap/yaml_map_test.go
+++ b/internal/yamlmap/yaml_map_test.go
@@ -209,6 +209,47 @@ func TestMapSetEntry(t *testing.T) {
 	}
 }
 
+func TestUnmarshal(t *testing.T) {
+	tests := []struct {
+		name      string
+		data      []byte
+		wantErr   string
+		wantEmpty bool
+	}{
+		{
+			name: "valid yaml",
+			data: []byte(`{test: "data"}`),
+		},
+		{
+			name:      "empty yaml",
+			data:      []byte(``),
+			wantEmpty: true,
+		},
+		{
+			name:    "invalid yaml",
+			data:    []byte(`{test: `),
+			wantErr: "invalid yaml",
+		},
+		{
+			name:    "invalid format",
+			data:    []byte(`data`),
+			wantErr: "invalid format",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m, err := Unmarshal(tt.data)
+			if tt.wantErr != "" {
+				assert.EqualError(t, err, tt.wantErr)
+				assert.Nil(t, m)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantEmpty, m.Empty())
+		})
+	}
+}
+
 func testMap() *Map {
 	var data = `
 valid: present

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -91,7 +91,6 @@ func Test_sshParser_absolutePath(t *testing.T) {
 		parentFile string
 		arg        string
 		want       string
-		wantErr    bool
 	}{
 		"absolute path": {
 			parentFile: "/etc/ssh/ssh_config",


### PR DESCRIPTION
This PR changes the behavior when reading empty config files, previously we would return an `ErrInvalidFormat` and now we will return a blank yaml map. This fixes backwards compatibility where some cli users had blank `host.yml` files.

Fixes https://github.com/cli/cli/issues/5949