### PR TITLE
Change tests to use t.Setenv instead of os.Setenv

### DIFF
--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -1,7 +1,6 @@
 package auth
 
 import (
-	"os"
 	"testing"
 
 	"github.com/cli/go-gh/pkg/config"
@@ -9,17 +8,6 @@ import (
 )
 
 func TestTokenForHost(t *testing.T) {
-	orig_GITHUB_TOKEN := os.Getenv("GITHUB_TOKEN")
-	orig_GITHUB_ENTERPRISE_TOKEN := os.Getenv("GITHUB_ENTERPRISE_TOKEN")
-	orig_GH_TOKEN := os.Getenv("GH_TOKEN")
-	orig_GH_ENTERPRISE_TOKEN := os.Getenv("GH_ENTERPRISE_TOKEN")
-	t.Cleanup(func() {
-		os.Setenv("GITHUB_TOKEN", orig_GITHUB_TOKEN)
-		os.Setenv("GITHUB_ENTERPRISE_TOKEN", orig_GITHUB_ENTERPRISE_TOKEN)
-		os.Setenv("GH_TOKEN", orig_GH_TOKEN)
-		os.Setenv("GH_ENTERPRISE_TOKEN", orig_GH_ENTERPRISE_TOKEN)
-	})
-
 	tests := []struct {
 		name                  string
 		host                  string
@@ -100,10 +88,10 @@ func TestTokenForHost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			os.Setenv("GITHUB_TOKEN", tt.githubToken)
-			os.Setenv("GITHUB_ENTERPRISE_TOKEN", tt.githubEnterpriseToken)
-			os.Setenv("GH_TOKEN", tt.ghToken)
-			os.Setenv("GH_ENTERPRISE_TOKEN", tt.ghEnterpriseToken)
+			t.Setenv("GITHUB_TOKEN", tt.githubToken)
+			t.Setenv("GITHUB_ENTERPRISE_TOKEN", tt.githubEnterpriseToken)
+			t.Setenv("GH_TOKEN", tt.ghToken)
+			t.Setenv("GH_ENTERPRISE_TOKEN", tt.ghEnterpriseToken)
 			token, source := tokenForHost(tt.config, tt.host)
 			assert.Equal(t, tt.wantToken, token)
 			assert.Equal(t, tt.wantSource, source)
@@ -152,10 +140,7 @@ func TestDefaultHost(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.ghHost != "" {
-				k := "GH_HOST"
-				old := os.Getenv(k)
-				os.Setenv(k, tt.ghHost)
-				defer os.Setenv(k, old)
+				t.Setenv("GH_HOST", tt.ghHost)
 			}
 			host, source := defaultHost(tt.config)
 			assert.Equal(t, tt.wantHost, host)
@@ -206,16 +191,10 @@ func TestKnownHosts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.ghHost != "" {
-				k := "GH_HOST"
-				old := os.Getenv(k)
-				os.Setenv(k, tt.ghHost)
-				defer os.Setenv(k, old)
+				t.Setenv("GH_HOST", tt.ghHost)
 			}
 			if tt.ghToken != "" {
-				k := "GH_TOKEN"
-				old := os.Getenv(k)
-				os.Setenv(k, tt.ghToken)
-				defer os.Setenv(k, old)
+				t.Setenv("GH_TOKEN", tt.ghToken)
 			}
 			hosts := knownHosts(tt.config)
 			assert.Equal(t, tt.wantHosts, hosts)

--- a/pkg/browser/browser_test.go
+++ b/pkg/browser/browser_test.go
@@ -84,9 +84,7 @@ func TestResolveLauncher(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != nil {
 				for k, v := range tt.env {
-					old := os.Getenv(k)
-					os.Setenv(k, v)
-					defer os.Setenv(k, old)
+					t.Setenv(k, v)
 				}
 			}
 			if tt.config != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -87,9 +87,7 @@ func TestConfigDir(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != nil {
 				for k, v := range tt.env {
-					old := os.Getenv(k)
-					os.Setenv(k, v)
-					defer os.Setenv(k, old)
+					t.Setenv(k, v)
 				}
 			}
 			assert.Equal(t, tt.output, ConfigDir())
@@ -151,9 +149,7 @@ func TestStateDir(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != nil {
 				for k, v := range tt.env {
-					old := os.Getenv(k)
-					os.Setenv(k, v)
-					defer os.Setenv(k, old)
+					t.Setenv(k, v)
 				}
 			}
 			assert.Equal(t, tt.output, StateDir())
@@ -215,9 +211,7 @@ func TestDataDir(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.env != nil {
 				for k, v := range tt.env {
-					old := os.Getenv(k)
-					os.Setenv(k, v)
-					defer os.Setenv(k, old)
+					t.Setenv(k, v)
 				}
 			}
 			assert.Equal(t, tt.output, DataDir())
@@ -374,9 +368,7 @@ func TestWrite(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tempDir := t.TempDir()
-			old := os.Getenv("GH_CONFIG_DIR")
-			os.Setenv("GH_CONFIG_DIR", tempDir)
-			defer os.Setenv("GH_CONFIG_DIR", old)
+			t.Setenv("GH_CONFIG_DIR", tempDir)
 			cfg := tt.createConfig()
 			err := Write(cfg)
 			assert.NoError(t, err)

--- a/pkg/repository/repository_test.go
+++ b/pkg/repository/repository_test.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"os"
 	"testing"
 
 	"github.com/cli/go-gh/pkg/config"
@@ -82,13 +81,9 @@ func TestParse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			oldDir := os.Getenv("GH_CONFIG_DIR")
-			os.Setenv("GH_CONFIG_DIR", "nonexistant")
-			defer os.Setenv("GH_CONFIG_DIR", oldDir)
+			t.Setenv("GH_CONFIG_DIR", "nonexistant")
 			if tt.hostOverride != "" {
-				old := os.Getenv("GH_HOST")
-				os.Setenv("GH_HOST", tt.hostOverride)
-				defer os.Setenv("GH_HOST", old)
+				t.Setenv("GH_HOST", tt.hostOverride)
 			}
 			r, err := Parse(tt.input)
 			if tt.wantErr != "" {


### PR DESCRIPTION
Now that we are using go 1.18 we can use `t.Setenv` to safely set environment variables in tests without worrying about them not getting unset. This PR changes our tests to use this new functionality.