### PR TITLE
Unconditionally resolve "ssh.github.com" to "github.com"

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -53,6 +53,7 @@ func NewTranslator() Translator {
 	for _, file := range configFiles {
 		_ = p.read(file)
 	}
+
 	return p.cfg
 }
 
@@ -75,8 +76,8 @@ func (c config) Translate(u *url.URL) *url.URL {
 	if !ok {
 		return u
 	}
-	if strings.EqualFold(u.Hostname(), "github.com") && strings.EqualFold(resolvedHost, "ssh.github.com") {
-		return u
+	if strings.EqualFold(resolvedHost, "ssh.github.com") {
+		resolvedHost = "github.com"
 	}
 	newURL, _ := url.Parse(u.String())
 	newURL.Host = resolvedHost

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -128,12 +128,14 @@ func Test_Translate(t *testing.T) {
 		aliases: map[string]string{
 			"gh":         "github.com",
 			"github.com": "ssh.github.com",
+			"my.gh.com":  "ssh.github.com",
 		},
 	}
 
 	cases := [][]string{
 		{"ssh://gh/o/r", "ssh://github.com/o/r"},
 		{"ssh://github.com/o/r", "ssh://github.com/o/r"},
+		{"ssh://my.gh.com", "ssh://github.com"},
 		{"https://gh/o/r", "https://gh/o/r"},
 	}
 


### PR DESCRIPTION
This functionality diverged (https://github.com/cli/cli/commit/c240ab9137db008609a0c8406ce27b1ff54917df) while migrating to `go-gh` for ssh config file parsing and translation so just re-adding it back in.

Fixes https://github.com/cli/cli/issues/6125