### PR TITLE
Fix HTTP error handling in `RESTClient.Request()` method

### DIFF
--- a/example_gh_test.go
+++ b/example_gh_test.go
@@ -77,10 +77,6 @@ func ExampleRESTClient_request() {
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode > 299 {
-		log.Fatal("server error")
-	}
-
 	f, err := os.CreateTemp("", "*_checksums.txt")
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
- Ensure that `Request()` calls HandleHTTPError so that any JSON error body properly gets parsed;
- Ensure that response body is closed after reading the error response.

Ref. https://github.com/cli/cli/issues/6429