### PR TITLE
Disable govulncheck due to false positive

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,21 +26,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
-
-  govulncheck:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: "1.19"
-
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
-
-      - name: Run govulncheck
-        run: govulncheck -v ./...


### PR DESCRIPTION
govulcheck detected a case where `--jq` user input directly constructs a regexp in gojq code, which govulncheck considers a failure since it can lead to denial-of-service attacks. This risk doesn't not affect us, however, since we're building CLI apps and not hosted apps. As a user, you can crash your own `gh` process using your own malicious input as much as you'd like.

govulncheck presently does not have a way of silencing or allow-listing specific violations, so this disables govulncheck completely.

Ref. https://github.com/cli/go-gh/actions/runs/3243823451/jobs/5319105048
Reverts https://github.com/cli/go-gh/pull/71