### PR TITLE
Correctly measure terminal size in GH_FORCE_TTY mode

### DIFF
--- a/pkg/term/env.go
+++ b/pkg/term/env.go
@@ -105,7 +105,7 @@ func (t Term) Size() (int, int, error) {
 	}
 
 	ttyOut := t.out
-	if !t.isTTY {
+	if ttyOut == nil || !IsTerminal(ttyOut) {
 		if f, err := openTTY(); err == nil {
 			defer f.Close()
 			ttyOut = f


### PR DESCRIPTION
This fixes measuring terminal size from the process even if stdout was redirected to a script or file.