### PR TITLE
Upgrade to Go 1.19

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        go: ["1.18", "1.19"]
+        go: ["1.19"]
 
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cli/go-gh
 
-go 1.18
+go 1.19
 
 require (
 	github.com/MakeNowJust/heredoc v1.0.0


### PR DESCRIPTION
This PR upgrades Go to version 1.19.