### PR TITLE
Only search secure storage for auth token

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -87,7 +87,7 @@ func tokenForHost(cfg *config.Config, host string) (string, string) {
 }
 
 func tokenFromGh(path string, host string) (string, string) {
-	cmd := exec.Command(path, "auth", "token", "--hostname", host)
+	cmd := exec.Command(path, "auth", "token", "--secure-storage", "--hostname", host)
 	result, err := cmd.Output()
 	if err != nil {
 		return "", "gh"


### PR DESCRIPTION
Follow up to https://github.com/cli/go-gh/pull/107. This is a small optimization to only check the secure storage if auth token is not found in other locations.