### PR TITLE
Handle errors when resolving ssh aliases to hostnames

### DIFF
--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -95,7 +95,11 @@ func (t *Translator) resolve(hostname string) (string, error) {
 		}
 	}
 
-	_ = sshCmd.Wait()
+	err = sshCmd.Wait()
+	if err != nil || resolvedHost == "" {
+		// handle failures by returning the original hostname unchanged
+		resolvedHost = hostname
+	}
 
 	if t.cacheMap == nil {
 		t.cacheMap = map[string]string{}


### PR DESCRIPTION
If something went wrong during `ssh -G <hostname>`, just return the hostname unchanged. Avoids the scenario in https://github.com/cli/cli/issues/7088