### PR TITLE
Expose IsColorForced

### DIFF
--- a/pkg/term/env.go
+++ b/pkg/term/env.go
@@ -52,7 +52,7 @@ func FromEnv() Term {
 		}
 	} else {
 		stdoutIsTTY = IsTerminal(os.Stdout)
-		isColorEnabled = envColorForced() || (!IsColorDisabled() && stdoutIsTTY)
+		isColorEnabled = IsColorForced() || (!IsColorDisabled() && stdoutIsTTY)
 	}
 
 	isVirtualTerminal := false
@@ -162,7 +162,8 @@ func IsColorDisabled() bool {
 	return os.Getenv("NO_COLOR") != "" || os.Getenv("CLICOLOR") == "0"
 }
 
-func envColorForced() bool {
+// IsColorForced returns true if environment variable CLICOLOR_FORCE is set to force colored terminal output.
+func IsColorForced() bool {
 	return os.Getenv("CLICOLOR_FORCE") != "" && os.Getenv("CLICOLOR_FORCE") != "0"
 }
 


### PR DESCRIPTION
Since IsColorDisabled - based on env vars - is public, also expose IsColorForced so the gamut of GitHub CLI env vars for color overrides are available to callers.

This is desirable when using something other than `term` which does not allow for mocking or otherwise capturing output. Since I use another library, access to APIs that encapsulate the various env vars the GitHub CLI (and extensions using this module) is ideal so my extensions can do a better job at matching the behavior of the CLI.
