### PR TITLE
docs: add missing import

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"log"
 	"github.com/cli/go-gh/v2"
+	"github.com/cli/go-gh/v2/pkg/api"
 )
 
 func main() {


### PR DESCRIPTION
When reading the readme, I noticed that the usage of `api.DefaultRESTClient()` isn't accompanied by a corresponding `import`. This adds the import so users can copy-paste this snippet.

Before:

```
./main.go:21:17: undefined: api
```

After:

```
7701	OPEN	`gh repo fork` doesn't check if a fork exists in an org	bug, needs-triage	2023-07-13 09:19:18 +0000 UTC
7699	OPEN	Ruleset subcommands shouldn't require being in a repo if using the `--org` flag	bug, p2	2023-07-12 20:21:48 +0000 UTC
7697	OPEN	Unable to run any gh commands, invalid character '<'	bug, needs-triage	2023-07-13 02:28:26 +0000 UTC
7691	OPEN	`project item-add` should accept list of issues	enhancement, needs-triage	2023-07-11 22:46:52 +0000 UTC
7684	OPEN	Support copying the default title for pull requests	enhancement, needs-triage	2023-07-10 18:59:17 +0000 UTC

[{v2.32.0} {v2.31.0} {v2.30.0} {v2.29.0} {v2.28.0} {v2.27.0} {v2.26.1} {v2.26.0} {v2.25.1} {v2.25.0} {v2.24.3} {v2.24.2} {v2.24.1} {v2.24.0} {v2.23.0} {v2.22.1} {v2.22.0} {v2.21.2} {v2.21.1} {v2.21.0} {v2.20.2} {v2.20.1} {v2.20.0} {v2.19.0} {v2.18.1} {v2.18.0} {v2.17.0} {v2.16.1} {v2.16.0} {v2.15.0}]
```