### PR TITLE
fix(sanitizer): treat correct `U+FFFD` as normal character

### DIFF
--- a/pkg/asciisanitizer/sanitizer.go
+++ b/pkg/asciisanitizer/sanitizer.go
@@ -47,7 +47,7 @@ func (t *Sanitizer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err 
 			return
 		}
 		r, size := utf8.DecodeRune(src)
-		if r == utf8.RuneError {
+		if r == utf8.RuneError && size == 1 {
 			if !atEOF {
 				err = transform.ErrShortSrc
 				return

--- a/pkg/asciisanitizer/sanitizer.go
+++ b/pkg/asciisanitizer/sanitizer.go
@@ -47,7 +47,7 @@ func (t *Sanitizer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err 
 			return
 		}
 		r, size := utf8.DecodeRune(src)
-		if r == utf8.RuneError && size == 1 {
+		if r == utf8.RuneError && size < 2 {
 			if !atEOF {
 				err = transform.ErrShortSrc
 				return


### PR DESCRIPTION
Fixes: #127.

As the length of `src` is larger than `1`, so the `utf8.DecodeRune()` will not return `(RuneError, 0)`, we can just check the following case: `(RuneError, 1)` to judge if there is a decode error.
