### PR TITLE
Add support to config for setting and writing blank values

### DIFF
--- a/internal/yamlmap/yaml_map.go
+++ b/internal/yamlmap/yaml_map.go
@@ -35,6 +35,13 @@ func MapValue() *Map {
 	}}
 }
 
+func NullValue() *Map {
+	return &Map{&yaml.Node{
+		Kind: yaml.ScalarNode,
+		Tag:  "!!null",
+	}}
+}
+
 func Unmarshal(data []byte) (*Map, error) {
 	var root yaml.Node
 	err := yaml.Unmarshal(data, &root)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -102,7 +102,12 @@ func (c *Config) Remove(keys []string) error {
 // Set a string value in a Config.
 // The keys argument is a sequence of key values so that nested
 // entries can be set. If any of the keys do not exist they will
-// be created.
+// be created. If the string value to be set is empty it will be
+// represented as null not an empty string when written.
+//
+//	var c *Config
+//	c.Set([]string{"key"}, "")
+//	Write(c) // writes `key: ` not `key: ""`
 func (c *Config) Set(keys []string, value string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -116,7 +121,11 @@ func (c *Config) Set(keys []string, value string) {
 		}
 		m = entry
 	}
-	m.SetEntry(keys[len(keys)-1], yamlmap.StringValue(value))
+	val := yamlmap.StringValue(value)
+	if value == "" {
+		val = yamlmap.NullValue()
+	}
+	m.SetEntry(keys[len(keys)-1], val)
 }
 
 func (c *Config) deepCopy() *Config {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -406,6 +406,18 @@ func TestWrite(t *testing.T) {
 	}
 }
 
+func TestWriteEmptyValues(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Setenv("GH_CONFIG_DIR", tempDir)
+	cfg := ReadFromString(testFullConfig())
+	cfg.Set([]string{"editor"}, "")
+	err := Write(cfg)
+	assert.NoError(t, err)
+	data, err := os.ReadFile(generalConfigFile())
+	assert.NoError(t, err)
+	assert.Equal(t, "git_protocol: ssh\neditor:\nprompt: enabled\npager: less\n", string(data))
+}
+
 func TestGet(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -594,6 +606,11 @@ func TestSet(t *testing.T) {
 			name:  "set non-existant nest",
 			keys:  []string{"johnny", "test"},
 			value: "dukey",
+		},
+		{
+			name:  "set empty value",
+			keys:  []string{"empty"},
+			value: "",
 		},
 	}
 


### PR DESCRIPTION
This PR updates the implementation of `config.Set` to set null yaml values instead of blank strings when passed a blank string as a value argument. We are not relying on the previous behavior anywhere and this allows us to create config keys even if they do not have any nested keys yet. We already work around this limitation in [auth login](https://github.com/cli/cli/blob/ce7d89de0cdc8f2e63021f2d2e252e3d7ff7f3b6/pkg/cmd/auth/login/login.go#L176) and we can finally remove that code. Additionally this is necessary for the work being done in this [branch](https://github.com/cli/cli/tree/wm/apply-multi-account-migration) which is not quiet ready for a PR yet.