### PR TITLE
Fix sanitization bug

### DIFF
--- a/pkg/asciisanitizer/sanitizer.go
+++ b/pkg/asciisanitizer/sanitizer.go
@@ -73,6 +73,7 @@ func (t *Sanitizer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err 
 					// Add an escape character when necessary to prevent creating
 					// invalid JSON with our replacements.
 					repl = append([]byte{'\\'}, repl...)
+					t.addEscape = false
 				}
 				err = transfer(repl, src[:6])
 				if err != nil {

--- a/pkg/asciisanitizer/sanitizer_test.go
+++ b/pkg/asciisanitizer/sanitizer_test.go
@@ -24,8 +24,8 @@ func TestSanitizerTransform(t *testing.T) {
 		{
 			name:  "JSON sanitization maintains valid JSON",
 			json:  true,
-			input: `\u001B \\u001B \\\u001B \\\\u001B`,
-			want:  `^[ \\^[ \\^[ \\\\^[`,
+			input: `\u001B \\u001B \\\u001B \\\\u001B \\u001B\\u001B`,
+			want:  `^[ \\^[ \\^[ \\\\^[ \\^[\\^[`,
 		},
 		{
 			name:  "JSON C0 control character",


### PR DESCRIPTION
Fixes https://github.com/cli/cli/issues/8336

There was a small bug in the logic of the sanitizer where multiple escaped ascii codes in a row would cause invalid JSON to be generated. This PR makes it so this does not happen. 