### PR TITLE
Config should load as unmodified

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,4 +23,4 @@ jobs:
       - name: Lint
         uses: golangci/golangci-lint-action@v3.4.0
         with:
-          version: v1.52
+          version: v1.54

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -213,6 +213,7 @@ func load(generalFilePath, hostsFilePath string, fallback *Config) (*Config, err
 
 	if hostsMap != nil && !hostsMap.Empty() {
 		generalMap.AddEntry("hosts", hostsMap)
+		generalMap.SetUnmodified()
 	}
 
 	if generalMap.Empty() && fallback != nil {


### PR DESCRIPTION
## Description

This PR relates to https://github.com/cli/cli/issues/8496

Since the [config was moved to `go-gh`](https://github.com/cli/go-gh/pull/44) this bug has been lurking around. The idea behind `IsModified` is that the config file shouldn't be written if only hosts has changed, and vice versa. Unfortunately, if there is a hosts file then on load of the files, the config entry would be `SetModified` as a result of having the hosts being added as an entry.

The consequence of this is that any call to `Write` would attempt to write the config file, even if only hosts had changed.

This PR sets the top level Config as unmodified to avoid that.

### Testing notes

This command should not write to the config file:

```
gh config set --host github.com boo bar
```

You can set the config file as immutable on Mac like so:

```
sudo chflags uchg ~/.config/gh/config.yml
```

and revert it with:

```
sudo chflags nouchg ~/.config/gh/config.yml
```