### PR TITLE
fix: handle empty response body

### DIFF
--- a/pkg/api/rest_client.go
+++ b/pkg/api/rest_client.go
@@ -105,9 +105,11 @@ func (c *RESTClient) DoWithContext(ctx context.Context, method string, path stri
 		return err
 	}
 
-	err = json.Unmarshal(b, &response)
-	if err != nil {
-		return err
+	if len(b) > 0 {
+		err = json.Unmarshal(b, &response)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/api/rest_client_test.go
+++ b/pkg/api/rest_client_test.go
@@ -303,6 +303,25 @@ func TestRESTClientPatch(t *testing.T) {
 	assert.True(t, gock.IsDone(), printPendingMocks(gock.Pending()))
 }
 
+// Covers https://docs.github.com/en/rest/activity/notifications?apiVersion=2022-11-28#mark-a-thread-as-read
+func TestRESTClientPatchNoResponseBody(t *testing.T) {
+	t.Cleanup(gock.Off)
+	gock.New("https://api.github.com").
+		Patch("/some/path/here").
+		BodyString(`{}`).
+		Reply(205).
+		BodyString("")
+	client, _ := NewRESTClient(ClientOptions{
+		Host:      "github.com",
+		AuthToken: "token",
+		Transport: http.DefaultTransport,
+	})
+	r := bytes.NewReader([]byte(`{}`))
+	err := client.Patch("some/path/here", r, nil)
+	assert.NoError(t, err)
+	assert.True(t, gock.IsDone(), printPendingMocks(gock.Pending()))
+}
+
 func TestRESTClientPost(t *testing.T) {
 	t.Cleanup(gock.Off)
 	gock.New("https://api.github.com").


### PR DESCRIPTION
This PR is a showcase of solution 1 for https://github.com/cli/go-gh/issues/161.

It adds an empty body check before trying to unmarshall it.