### PR TITLE
Use api subdomain for REST and GQL clients when host is tenant

### DIFF
--- a/pkg/api/graphql_client_test.go
+++ b/pkg/api/graphql_client_test.go
@@ -293,6 +293,11 @@ func TestGraphQLEndpoint(t *testing.T) {
 			host:         "enterprise.com",
 			wantEndpoint: "https://enterprise.com/api/graphql",
 		},
+		{
+			name:         "tenant",
+			host:         "tenant.ghe.com",
+			wantEndpoint: "https://api.tenant.ghe.com/graphql",
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/api/http_client.go
+++ b/pkg/api/http_client.go
@@ -135,7 +135,14 @@ func isGarage(host string) bool {
 }
 
 func isEnterprise(host string) bool {
-	return host != github && host != localhost
+	return host != github && host != localhost && !isTenancy(host)
+}
+
+// tenancyHost is the domain name of a tenancy GitHub instance.
+const tenancyHost = "ghe.com"
+
+func isTenancy(host string) bool {
+	return strings.HasSuffix(host, "."+tenancyHost)
 }
 
 func normalizeHostname(hostname string) string {
@@ -145,6 +152,14 @@ func normalizeHostname(hostname string) string {
 	}
 	if strings.HasSuffix(hostname, "."+localhost) {
 		return localhost
+	}
+	// This has been copied over from the cli/cli NormalizeHostname function
+	// to ensure compatible behaviour but we don't fully understand when or
+	// why it would be useful here. We can't see what harm will come of
+	// duplicating the logic.
+	if before, found := strings.CutSuffix(hostname, "."+tenancyHost); found {
+		idx := strings.LastIndex(before, ".")
+		return fmt.Sprintf("%s.%s", before[idx+1:], tenancyHost)
 	}
 	return hostname
 }

--- a/pkg/api/rest_client_test.go
+++ b/pkg/api/rest_client_test.go
@@ -474,6 +474,11 @@ func TestRestPrefix(t *testing.T) {
 			host:         "enterprise.com",
 			wantEndpoint: "https://enterprise.com/api/v3/",
 		},
+		{
+			name:         "tenant",
+			host:         "tenant.ghe.com",
+			wantEndpoint: "https://api.tenant.ghe.com/",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Description

When targeting the API of tenants we should be using the subdomain rather than the path prefix.

### Implementation Choices

Right now, I took the straightest path to implementing this, which included copying functions from the `auth` package. It was an intentional choice not to DRY this out because I want to derisk this work and then review it with confidence that the black box behaviour is correct.

### How To Test

The easiest way to black box validate these changes is to use the PR in `cli/cli` that pins to the [commit sha.](https://github.com/cli/cli/pull/9618)

Alternatively, replace the dependency in `cli/cli` like so:

```
go mod edit -replace github.com/cli/go-gh/v2=/path/to/go-gh
```

Then build and run the CLI with commands that use these clients such as:

```
GH_DEBUG=api GH_HOST=tenant.ghe.com ./bin/gh secret list --repo whatever/whatever # REST
GH_DEBUG=api GH_HOST=tenant.ghe.com ./bin/gh repo list # GQL
```

In both cases the HTTP requests should demonstrate the API subdomain being used instead of the path prefix.