### PR TITLE
Realign accessible color logic around new env var

### DIFF
--- a/pkg/accessibility/accessibility.go
+++ b/pkg/accessibility/accessibility.go
@@ -6,16 +6,23 @@ import (
 	"github.com/cli/go-gh/v2/pkg/config"
 )
 
-// ACCESSIBILITY_ENV is the name of the environment variable that can be used to enable
-// accessibility features. If the value is empty, "0", or "false", the accessibility
-// features are disabled. Any other value enables the accessibility features. Note that
-// this environment variable supercedes the configuration file's accessible setting.
-const ACCESSIBILITY_ENV = "ACCESSIBLE"
+const (
+	// AccessibleColorsEnv is the name of the environment variable to enable accessibile color features.
+	AccessibleColorsEnv = "GH_ACCESSIBLE_COLORS"
 
-// IsEnabled returns true if accessibility features are enabled via the ACCESSIBLE
-// environment variable or the configuration file.
-func IsEnabled() bool {
-	envVar := os.Getenv(ACCESSIBILITY_ENV)
+	// AccessibleColorsSetting is the name of the `gh config` setting to enable accessibile color features.
+	AccessibleColorsSetting = "accessible_colors"
+)
+
+// IsAccessibleColorsEnabled returns true if accessibility colors are enabled via environment variable
+// or configuration settings.
+//
+// If the environment variable is empty, "0", or "false", the accessibility colors are disabled.
+// Any other value enables the accessibility features.
+//
+// Note that this environment variable supercedes the configuration file's accessible setting.
+func IsAccessibleColorsEnabled() bool {
+	envVar := os.Getenv(AccessibleColorsEnv)
 	if envVar != "" {
 		return isEnvVarEnabled(envVar)
 	}
@@ -23,7 +30,7 @@ func IsEnabled() bool {
 	// We are not handling errors because we don't want to fail if the config is not
 	// read. Instead, we assume an empty configuration is equivalent to "disabled".
 	cfg, _ := config.Read(nil)
-	accessibleConfigValue, _ := cfg.Get([]string{"accessible"})
+	accessibleConfigValue, _ := cfg.Get([]string{AccessibleColorsSetting})
 
 	return accessibleConfigValue == "enabled"
 }

--- a/pkg/accessibility/accessibility_test.go
+++ b/pkg/accessibility/accessibility_test.go
@@ -3,11 +3,12 @@ package accessibility
 import (
 	"testing"
 
+	"github.com/MakeNowJust/heredoc"
 	"github.com/cli/go-gh/v2/internal/testutils"
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsEnabled(t *testing.T) {
+func TestIsAccessibleColorsEnabled(t *testing.T) {
 	tests := []struct {
 		name        string
 		envVarValue string
@@ -21,19 +22,19 @@ func TestIsEnabled(t *testing.T) {
 			wantOut:     false,
 		},
 		{
-			name:        "When the accessibility configuration is unset but the ACCESSIBLE env var is set to something truthy (not '0' or 'false'), it should return true",
+			name:        "When the accessibility configuration is unset but the env var is set to something truthy (not '0' or 'false'), it should return true",
 			envVarValue: "1",
 			cfgStr:      "",
 			wantOut:     true,
 		},
 		{
-			name:        "When the accessibility configuration is unset and the ACCESSIBLE env var returns '0', it should return false",
+			name:        "When the accessibility configuration is unset and the env var returns '0', it should return false",
 			envVarValue: "0",
 			cfgStr:      "",
 			wantOut:     false,
 		},
 		{
-			name:        "When the accessibility configuration is unset and the ACCESSIBLE env var returns 'false', it should return false",
+			name:        "When the accessibility configuration is unset and the env var returns 'false', it should return false",
 			envVarValue: "false",
 			cfgStr:      "",
 			wantOut:     false,
@@ -71,21 +72,21 @@ func TestIsEnabled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("ACCESSIBLE", tt.envVarValue)
+			t.Setenv("GH_ACCESSIBLE_COLORS", tt.envVarValue)
 			testutils.StubConfig(t, tt.cfgStr)
-			assert.Equal(t, tt.wantOut, IsEnabled())
+			assert.Equal(t, tt.wantOut, IsAccessibleColorsEnabled())
 		})
 	}
 }
 
 func accessibilityEnabledConfig() string {
-	return `
-accessible: enabled
-`
+	return heredoc.Docf(`
+		%s: enabled
+	`, AccessibleColorsSetting)
 }
 
 func accessibilityDisabledConfig() string {
-	return `
-accessible: disabled
-`
+	return heredoc.Docf(`
+		%s: disabled
+	`, AccessibleColorsSetting)
 }

--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -34,7 +34,7 @@ func WithWrap(w int) glamour.TermRendererOption {
 // If the environment variable GLAMOUR_STYLE is set, it will take precedence over the provided theme.
 func WithTheme(theme string) glamour.TermRendererOption {
 	style := os.Getenv("GLAMOUR_STYLE")
-	accessible := accessibility.IsEnabled()
+	accessible := accessibility.IsAccessibleColorsEnabled()
 	if style == "" || style == "auto" {
 		switch theme {
 		case "light", "dark":

--- a/pkg/markdown/markdown.go
+++ b/pkg/markdown/markdown.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/cli/glamour"
-	"github.com/cli/go-gh/v2/pkg/accessibility"
+	"github.com/cli/go-gh/v2/pkg/x/color"
 )
 
 // WithoutIndentation is a rendering option that removes indentation from the markdown rendering.
@@ -34,7 +34,7 @@ func WithWrap(w int) glamour.TermRendererOption {
 // If the environment variable GLAMOUR_STYLE is set, it will take precedence over the provided theme.
 func WithTheme(theme string) glamour.TermRendererOption {
 	style := os.Getenv("GLAMOUR_STYLE")
-	accessible := accessibility.IsAccessibleColorsEnabled()
+	accessible := color.IsAccessibleColorsEnabled()
 	if style == "" || style == "auto" {
 		switch theme {
 		case "light", "dark":

--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -133,7 +133,7 @@ func Test_RenderAccessible(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.accessible {
-				t.Setenv(accessibility.ACCESSIBILITY_ENV, "true")
+				t.Setenv(accessibility.AccessibleColorsEnv, "true")
 			}
 
 			out, err := Render(tt.text, WithTheme(tt.theme))
@@ -247,7 +247,7 @@ func Test_RenderColor(t *testing.T) {
 				// Chroma caches charm style used to render codeblocks, it must be unregistered to avoid previously used style being reused.
 				delete(styles.Registry, "charm")
 			})
-			t.Setenv(accessibility.ACCESSIBILITY_ENV, tt.accessibleEnvVar)
+			t.Setenv(accessibility.AccessibleColorsEnv, tt.accessibleEnvVar)
 
 			if tt.styleEnvVar != "" {
 				path := filepath.Join(t.TempDir(), fmt.Sprintf("%s.json", tt.styleEnvVar))

--- a/pkg/markdown/markdown_test.go
+++ b/pkg/markdown/markdown_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/MakeNowJust/heredoc"
 	"github.com/alecthomas/chroma/v2/styles"
-	"github.com/cli/go-gh/v2/pkg/accessibility"
+	"github.com/cli/go-gh/v2/pkg/x/color"
 	ansi "github.com/leaanthony/go-ansi-parser"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -133,7 +133,7 @@ func Test_RenderAccessible(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.accessible {
-				t.Setenv(accessibility.AccessibleColorsEnv, "true")
+				t.Setenv(color.AccessibleColorsEnv, "true")
 			}
 
 			out, err := Render(tt.text, WithTheme(tt.theme))
@@ -247,7 +247,7 @@ func Test_RenderColor(t *testing.T) {
 				// Chroma caches charm style used to render codeblocks, it must be unregistered to avoid previously used style being reused.
 				delete(styles.Registry, "charm")
 			})
-			t.Setenv(accessibility.AccessibleColorsEnv, tt.accessibleEnvVar)
+			t.Setenv(color.AccessibleColorsEnv, tt.accessibleEnvVar)
 
 			if tt.styleEnvVar != "" {
 				path := filepath.Join(t.TempDir(), fmt.Sprintf("%s.json", tt.styleEnvVar))

--- a/pkg/x/color/accessibility.go
+++ b/pkg/x/color/accessibility.go
@@ -1,4 +1,4 @@
-package accessibility
+package color
 
 import (
 	"os"
@@ -14,13 +14,13 @@ const (
 	AccessibleColorsSetting = "accessible_colors"
 )
 
-// IsAccessibleColorsEnabled returns true if accessibility colors are enabled via environment variable
-// or configuration settings.
+// IsAccessibleColorsEnabled returns true if accessible colors are enabled via environment variable
+// or configuration setting with the environment variable having higher precedence.
 //
-// If the environment variable is empty, "0", or "false", the accessibility colors are disabled.
-// Any other value enables the accessibility features.
+// If the environment variable is empty, "0", or "false", the accessible colors are disabled.
+// Any other value enables the accessibility feature.
 //
-// Note that this environment variable supercedes the configuration file's accessible setting.
+// Note this is an experimental feature that is subject to change.
 func IsAccessibleColorsEnabled() bool {
 	envVar := os.Getenv(AccessibleColorsEnv)
 	if envVar != "" {

--- a/pkg/x/color/accessibility_test.go
+++ b/pkg/x/color/accessibility_test.go
@@ -1,4 +1,4 @@
-package accessibility
+package color
 
 import (
 	"testing"

--- a/pkg/x/x.go
+++ b/pkg/x/x.go
@@ -1,0 +1,4 @@
+// `x` is a collection of experimental features being used within the GitHub CLI following common Go conventions.
+//
+// Anything contained is subject to change without notice until it is considered stable enough to be promoted.
+package x


### PR DESCRIPTION
Relates github/cli#830

1. Updates existing accessibility detection logic specifically around accessible colors
2. Updates to testing regarding changes
3. Various other enhancements to related code and comments
