### PR TITLE
Expose `replace` sprig function

### DIFF
--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -272,6 +272,7 @@ func sprigFuncMap() template.FuncMap {
 		"hasPrefix",
 		"hasSuffix",
 		"regexMatch",
+		"replace",
 	}
 	txtFuncMap := sprig.TxtFuncMap()
 	funcMap := template.FuncMap{}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -409,6 +409,14 @@ func TestExecute(t *testing.T) {
 			},
 			wantW: "true",
 		},
+		{
+			name: "replace",
+			args: args{
+				json:     strings.NewReader(`{"product":"GitHub CLI\n"}`),
+				template: `{{ .product | replace "\n" "" }}`,
+			},
+			wantW: "GitHub CLI",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Related: https://github.com/cli/cli/issues/11572

- Exposed `replace` sprig function
  - See https://masterminds.github.io/sprig/strings.html#replace
- Added test

### Local testing by replacing `go-gh` module

#### `cli/go.mod`

```
replace github.com/cli/go-gh/v2 => ../go-gh
```

#### Test

```shell
# Get the title of the first issue from `cli/go-gh` repo
$ ./bin/gh issue list --repo cli/go-gh --limit 1 --json title --jq .[].title
Use UserCacheDir and UserConfigDir instead of custom implementation


# Get the title of the first issue from `cli/go-gh` repo and replace spaces with ellipsis
$ ./bin/gh issue list --repo cli/go-gh --limit 1 --json title --template '{{range .}}{{.title | replace " " "..."}}{{end}}'
Use...UserCacheDir...and...UserConfigDir...instead...of...custom...implementation
```

Signed-off-by: Azeem Sajid <azeem.sajid@gmail.com>