### PR TITLE
docs(pkg/api): explain `HandleHTTPError` does not close response body

### DIFF
--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -98,6 +98,8 @@ func matchPath(p, expect string) bool {
 }
 
 // HandleHTTPError parses a http.Response into a HTTPError.
+//
+// The function attempts to read the response's body, but it does not close it.
 func HandleHTTPError(resp *http.Response) error {
 	httpError := &HTTPError{
 		Headers:    resp.Header,


### PR DESCRIPTION
Related to https://github.com/cli/cli/pull/12084.