### PR TITLE
config: allow overriding data directory via `GH_DATA_DIR`

### DIFF
--- a/pkg/api/client_options_test.go
+++ b/pkg/api/client_options_test.go
@@ -9,6 +9,9 @@ import (
 )
 
 func TestResolveOptions(t *testing.T) {
+	t.Setenv("GH_CONFIG_DIR", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
 	testutils.StubConfig(t, testConfigWithSocket())
 
 	tests := []struct {

--- a/pkg/api/graphql_client_test.go
+++ b/pkg/api/graphql_client_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestGraphQLClient(t *testing.T) {
+	t.Setenv("GH_CONFIG_DIR", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
 	testutils.StubConfig(t, testConfig())
 	t.Cleanup(gock.Off)
 
@@ -35,6 +38,9 @@ func TestGraphQLClient(t *testing.T) {
 }
 
 func TestGraphQLClientDoError(t *testing.T) {
+	t.Setenv("GH_CONFIG_DIR", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
 	testutils.StubConfig(t, testConfig())
 	t.Cleanup(gock.Off)
 
@@ -57,6 +63,9 @@ func TestGraphQLClientDoError(t *testing.T) {
 }
 
 func TestGraphQLClientQueryError(t *testing.T) {
+	t.Setenv("GH_CONFIG_DIR", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
 	testutils.StubConfig(t, testConfig())
 	t.Cleanup(gock.Off)
 
@@ -79,6 +88,9 @@ func TestGraphQLClientQueryError(t *testing.T) {
 }
 
 func TestGraphQLClientMutateError(t *testing.T) {
+	t.Setenv("GH_CONFIG_DIR", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
 	testutils.StubConfig(t, testConfig())
 	t.Cleanup(gock.Off)
 

--- a/pkg/api/http_client_test.go
+++ b/pkg/api/http_client_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestHTTPClient(t *testing.T) {
+	t.Setenv("GH_CONFIG_DIR", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
 	testutils.StubConfig(t, testConfig())
 	t.Cleanup(gock.Off)
 

--- a/pkg/api/rest_client_test.go
+++ b/pkg/api/rest_client_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestRESTClient(t *testing.T) {
+	t.Setenv("GH_CONFIG_DIR", "")
+	t.Setenv("GH_TOKEN", "")
+	t.Setenv("GITHUB_TOKEN", "")
 	testutils.StubConfig(t, testConfig())
 	t.Cleanup(gock.Off)
 

--- a/pkg/auth/auth_test.go
+++ b/pkg/auth/auth_test.go
@@ -238,6 +238,9 @@ func TestKnownHosts(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("GH_CONFIG_DIR", "")
+			t.Setenv("GH_HOST", "")
+			t.Setenv("GH_TOKEN", "")
 			if tt.ghHost != "" {
 				t.Setenv("GH_HOST", tt.ghHost)
 			}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,6 +17,7 @@ import (
 const (
 	appData       = "AppData"
 	ghConfigDir   = "GH_CONFIG_DIR"
+	ghDataDir     = "GH_DATA_DIR"
 	localAppData  = "LocalAppData"
 	xdgConfigHome = "XDG_CONFIG_HOME"
 	xdgDataHome   = "XDG_DATA_HOME"
@@ -280,16 +281,18 @@ func StateDir() string {
 
 // DataDir returns the path to the data directory.
 //
-// Data path precedence: XDG_DATA_HOME, LocalAppData (windows only), HOME.
+// Data path precedence: GH_DATA_DIR, XDG_DATA_HOME, LocalAppData (windows only), HOME.
 func DataDir() string {
 	var path string
-	if a := os.Getenv(xdgDataHome); a != "" {
-		path = filepath.Join(a, "gh")
-	} else if b := os.Getenv(localAppData); runtime.GOOS == "windows" && b != "" {
-		path = filepath.Join(b, "GitHub CLI")
+	if a := os.Getenv(ghDataDir); a != "" {
+		path = a
+	} else if b := os.Getenv(xdgDataHome); b != "" {
+		path = filepath.Join(b, "gh")
+	} else if c := os.Getenv(localAppData); runtime.GOOS == "windows" && c != "" {
+		path = filepath.Join(c, "GitHub CLI")
 	} else {
-		c, _ := os.UserHomeDir()
-		path = filepath.Join(c, ".local", "share", "gh")
+		d, _ := os.UserHomeDir()
+		path = filepath.Join(d, ".local", "share", "gh")
 	}
 	return path
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -41,6 +41,7 @@ func TestConfigDir(t *testing.T) {
 		{
 			name: "XDG_CONFIG_HOME specified",
 			env: map[string]string{
+				"GH_CONFIG_DIR":   "",
 				"XDG_CONFIG_HOME": tempDir,
 			},
 			output: filepath.Join(tempDir, "gh"),
@@ -57,7 +58,8 @@ func TestConfigDir(t *testing.T) {
 			name:        "AppData specified",
 			onlyWindows: true,
 			env: map[string]string{
-				"AppData": tempDir,
+				"GH_CONFIG_DIR": "",
+				"AppData":       tempDir,
 			},
 			output: filepath.Join(tempDir, "GitHub CLI"),
 		},
@@ -74,6 +76,7 @@ func TestConfigDir(t *testing.T) {
 			name:        "XDG_CONFIG_HOME and AppData specified",
 			onlyWindows: true,
 			env: map[string]string{
+				"GH_CONFIG_DIR":   "",
 				"XDG_CONFIG_HOME": tempDir,
 				"AppData":         tempDir,
 			},
@@ -170,6 +173,7 @@ func TestDataDir(t *testing.T) {
 		{
 			name: "HOME/USERPROFILE specified",
 			env: map[string]string{
+				"GH_DATA_DIR":     "",
 				"XDG_DATA_HOME":   "",
 				"GH_CONFIG_DIR":   "",
 				"XDG_CONFIG_HOME": "",
@@ -182,6 +186,7 @@ func TestDataDir(t *testing.T) {
 		{
 			name: "XDG_DATA_HOME specified",
 			env: map[string]string{
+				"GH_DATA_DIR":   "",
 				"XDG_DATA_HOME": tempDir,
 			},
 			output: filepath.Join(tempDir, "gh"),
@@ -190,6 +195,7 @@ func TestDataDir(t *testing.T) {
 			name:        "LocalAppData specified",
 			onlyWindows: true,
 			env: map[string]string{
+				"GH_DATA_DIR":  "",
 				"LocalAppData": tempDir,
 			},
 			output: filepath.Join(tempDir, "GitHub CLI"),
@@ -198,6 +204,7 @@ func TestDataDir(t *testing.T) {
 			name:        "XDG_DATA_HOME and LocalAppData specified",
 			onlyWindows: true,
 			env: map[string]string{
+				"GH_DATA_DIR":   "",
 				"XDG_DATA_HOME": tempDir,
 				"LocalAppData":  tempDir,
 			},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -210,6 +210,21 @@ func TestDataDir(t *testing.T) {
 			},
 			output: filepath.Join(tempDir, "gh"),
 		},
+		{
+			name: "GH_DATA_DIR specified",
+			env: map[string]string{
+				"GH_DATA_DIR": filepath.Join(tempDir, "gh_data_dir"),
+			},
+			output: filepath.Join(tempDir, "gh_data_dir"),
+		},
+		{
+			name: "GH_DATA_DIR and XDG_DATA_HOME specified",
+			env: map[string]string{
+				"GH_DATA_DIR":   filepath.Join(tempDir, "gh_data_dir"),
+				"XDG_DATA_HOME": tempDir,
+			},
+			output: filepath.Join(tempDir, "gh_data_dir"),
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Hey, this is a bit of a drive-by PR but I think it's quite small in nature and fills in a gap that'd help with consistency. I've added support for overriding the data directory via a `GH_DATA_DIR` environment variable, which is akin to `GH_CONFIG_DIR`. This is nice for users who want a global/user-agnostic configuration, and don't want to pollute their home dirs. In my case, I want to manage extensions in a different directory than the default (I use NixOS and want to have my config be read-only in `/etc/gh`).

The precedence for locating the data dir is now `GH_DATA_DIR` --> `XDG_DATA_HOME` --> `LocalAppData` (Windows) --> `HOME`


While I was at it, I also fixed tests that suffered from environment pollution. I set `GH_TOKEN` and this was breaking some tests.

Thanks a ton!

N.B. If accepted, I can help update the main CLI repo with docs :)