### PR TITLE
Adding application/octocat-stream to list of inspectable MIME types

### DIFF
--- a/pkg/api/http_client.go
+++ b/pkg/api/http_client.go
@@ -122,6 +122,7 @@ func NewHTTPClient(opts ClientOptions) (*http.Client, error) {
 func inspectableMIMEType(t string) bool {
 	return strings.HasPrefix(t, "text/") ||
 		strings.HasPrefix(t, "application/x-www-form-urlencoded") ||
+		strings.HasPrefix(t, "application/octocat-stream") ||
 		jsonTypeRE.MatchString(t)
 }
 

--- a/pkg/api/http_client_test.go
+++ b/pkg/api/http_client_test.go
@@ -184,3 +184,59 @@ func printPendingMocks(mocks []gock.Mock) string {
 	}
 	return fmt.Sprintf("%d unmatched mocks: %s", len(paths), strings.Join(paths, ", "))
 }
+
+func TestInspectableMIMEType(t *testing.T) {
+	tests := []struct {
+		name     string
+		mimeType string
+		want     bool
+	}{
+		{
+			name:     "text/plain is inspectable",
+			mimeType: "text/plain",
+			want:     true,
+		},
+		{
+			name:     "text/html is inspectable",
+			mimeType: "text/html",
+			want:     true,
+		},
+		{
+			name:     "application/json is inspectable",
+			mimeType: "application/json",
+			want:     true,
+		},
+		{
+			name:     "application/json with charset is inspectable",
+			mimeType: "application/json; charset=utf-8",
+			want:     true,
+		},
+		{
+			name:     "application/x-www-form-urlencoded is inspectable",
+			mimeType: "application/x-www-form-urlencoded",
+			want:     true,
+		},
+		{
+			name:     "application/octocat-stream is inspectable",
+			mimeType: "application/octocat-stream",
+			want:     true,
+		},
+		{
+			name:     "application/octet-stream is not inspectable",
+			mimeType: "application/octet-stream",
+			want:     false,
+		},
+		{
+			name:     "image/png is not inspectable",
+			mimeType: "image/png",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inspectableMIMEType(tt.mimeType)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
Fixes: #210
Relates to: https://github.com/github/rest-api-description/issues/5178  

This pull request updates the logic for determining which MIME types are considered "inspectable" and adds comprehensive unit tests to ensure correct behavior. The main change is the inclusion of the `application/octocat-stream` MIME type as inspectable.

I also manually tested this change by replacing the `cli/go-gh` package for cli/cli locally and verified that running `gh api --verbose /octocat` output the ASCII art response.