### PR TITLE
Pin REST API version to 2022-11-28

### DIFF
--- a/pkg/api/http_client.go
+++ b/pkg/api/http_client.go
@@ -22,6 +22,8 @@ import (
 const (
 	accept          = "Accept"
 	authorization   = "Authorization"
+	apiVersion      = "X-GitHub-Api-Version"
+	apiVersionValue = "2022-11-28"
 	contentType     = "Content-Type"
 	github          = "github.com"
 	jsonContentType = "application/json; charset=utf-8"
@@ -162,6 +164,9 @@ func resolveHeaders(headers map[string]string) {
 		if tz != "" {
 			headers[timeZone] = tz
 		}
+	}
+	if _, ok := headers[apiVersion]; !ok {
+		headers[apiVersion] = apiVersionValue
 	}
 	if _, ok := headers[accept]; !ok {
 		// Preview for PullRequest.mergeStateStatus.

--- a/pkg/api/http_client.go
+++ b/pkg/api/http_client.go
@@ -114,7 +114,7 @@ func NewHTTPClient(opts ClientOptions) (*http.Client, error) {
 		opts.Headers = map[string]string{}
 	}
 	if !opts.SkipDefaultHeaders {
-		resolveHeaders(opts.Headers)
+		setDefaultHeaders(opts.Headers)
 	}
 	transport = newHeaderRoundTripper(opts.Host, opts.AuthToken, opts.Headers, transport)
 
@@ -143,7 +143,7 @@ type headerRoundTripper struct {
 	rt      http.RoundTripper
 }
 
-func resolveHeaders(headers map[string]string) {
+func setDefaultHeaders(headers map[string]string) {
 	if _, ok := headers[contentType]; !ok {
 		headers[contentType] = jsonContentType
 	}

--- a/pkg/api/http_client_test.go
+++ b/pkg/api/http_client_test.go
@@ -122,6 +122,7 @@ func TestNewHTTPClient(t *testing.T) {
 			wantHeaders: func() http.Header {
 				h := defaultHeaders()
 				h.Del(accept)
+				h.Del(apiVersion)
 				h.Del(contentType)
 				h.Del(timeZone)
 				h.Del(userAgent)
@@ -169,6 +170,7 @@ func defaultHeaders() http.Header {
 	h := http.Header{}
 	a := "application/vnd.github.merge-info-preview+json"
 	a += ", application/vnd.github.nebula-preview"
+	h.Set(apiVersion, apiVersionValue)
 	h.Set(contentType, jsonContentType)
 	h.Set(userAgent, "go-gh")
 	h.Set(authorization, fmt.Sprintf("token %s", "oauth_token"))


### PR DESCRIPTION
## Description

Currently, `go-gh` does not set the `X-GitHub-Api-Version` header, meaning if/when a new version rolls out, consumers of `go-gh` using APIs that have breaking changes may begin breaking.

This adds `X-GitHub-Api-Version: 2022-11-28` as a default header in `resolveHeaders()`, following the same pattern as the other defaults (Content-Type, User-Agent, etc.). Consumers can override it via `ClientOptions.Headers`, and `SkipDefaultHeaders: true` excludes it as expected.

See: https://github.blog/developer-skills/github/to-infinity-and-beyond-enabling-the-future-of-githubs-rest-api-with-api-versioning/