### PR TITLE
Remove dependency on archived github.com/cli/safeexec

### DIFF
--- a/gh.go
+++ b/gh.go
@@ -12,8 +12,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-
-	"github.com/cli/safeexec"
 )
 
 // Exec invokes a gh command in a subprocess and captures the output and error streams.
@@ -52,7 +50,7 @@ func Path() (string, error) {
 	if ghExe := os.Getenv("GH_PATH"); ghExe != "" {
 		return ghExe, nil
 	}
-	return safeexec.LookPath("gh")
+	return exec.LookPath("gh")
 }
 
 func run(ctx context.Context, ghExe string, env []string, stdin io.Reader, stdout, stderr io.Writer, args []string) error {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/charmbracelet/glamour v0.9.2-0.20250319212134-549f544650e3
 	github.com/charmbracelet/lipgloss v1.1.1-0.20250319133953-166f707985bc
 	github.com/cli/browser v1.3.0
-	github.com/cli/safeexec v1.0.0
 	github.com/cli/shurcooL-graphql v0.0.4
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/henvic/httpretty v0.0.6

--- a/go.sum
+++ b/go.sum
@@ -40,8 +40,6 @@ github.com/charmbracelet/x/term v0.2.1 h1:AQeHeLZ1OqSXhrAWpYUtZyX1T3zVxfpZuEQMIQ
 github.com/charmbracelet/x/term v0.2.1/go.mod h1:oQ4enTYFV7QN4m0i9mzHrViD7TQKvNEEkHUMCmsxdUg=
 github.com/cli/browser v1.3.0 h1:LejqCrpWr+1pRqmEPDGnTZOjsMe7sehifLynZJuqJpo=
 github.com/cli/browser v1.3.0/go.mod h1:HH8s+fOAxjhQoBUAsKuPCbqUuxZDhQ2/aD+SzsEfBTk=
-github.com/cli/safeexec v1.0.0 h1:0VngyaIyqACHdcMNWfo6+KdUYnqEr2Sg+bSP1pdF+dI=
-github.com/cli/safeexec v1.0.0/go.mod h1:Z/D4tTN8Vs5gXYHDCbaM1S/anmEDnJb1iW0+EJ5zx3Q=
 github.com/cli/shurcooL-graphql v0.0.4 h1:6MogPnQJLjKkaXPyGqPRXOI2qCsQdqNfUY1QSJu2GuY=
 github.com/cli/shurcooL-graphql v0.0.4/go.mod h1:3waN4u02FiZivIV+p1y4d0Jo1jc6BViMA73C+sZo2fk=
 github.com/clipperhouse/stringish v0.1.1 h1:+NSqMOr3GR6k1FdRhhnXrLfztGzuG+VuFDfatpWHKCs=

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
-
-	"github.com/cli/safeexec"
 )
 
 func Exec(args ...string) (stdOut, stdErr bytes.Buffer, err error) {
@@ -18,7 +16,7 @@ func Exec(args ...string) (stdOut, stdErr bytes.Buffer, err error) {
 }
 
 func path() (string, error) {
-	return safeexec.LookPath("git")
+	return exec.LookPath("git")
 }
 
 func run(path string, env []string, args ...string) (stdOut, stdErr bytes.Buffer, err error) {

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cli/go-gh/v2/internal/set"
 	"github.com/cli/go-gh/v2/pkg/config"
-	"github.com/cli/safeexec"
 )
 
 const (
@@ -40,7 +39,7 @@ func TokenForHost(host string) (string, string) {
 
 	ghExe := os.Getenv("GH_PATH")
 	if ghExe == "" {
-		ghExe, _ = safeexec.LookPath("gh")
+		ghExe, _ = exec.LookPath("gh")
 	}
 
 	if ghExe != "" {

--- a/pkg/browser/browser.go
+++ b/pkg/browser/browser.go
@@ -10,7 +10,6 @@ import (
 
 	cliBrowser "github.com/cli/browser"
 	"github.com/cli/go-gh/v2/pkg/config"
-	"github.com/cli/safeexec"
 	"github.com/google/shlex"
 )
 
@@ -65,7 +64,7 @@ func (b *Browser) browse(url string, env []string) error {
 	if err != nil {
 		return err
 	}
-	launcherExe, err := safeexec.LookPath(launcherArgs[0])
+	launcherExe, err := exec.LookPath(launcherArgs[0])
 	if err != nil {
 		return err
 	}
@@ -128,8 +127,8 @@ func isPossibleProtocol(u string) (*url.URL, error) {
 	}
 
 	// Disallow URLs that match executables found in the user path.
-	exec, _ := safeexec.LookPath(u)
-	if exec != "" {
+	exe, _ := exec.LookPath(u)
+	if exe != "" {
 		return nil, fmt.Errorf("opening executables is unsupported: %s", u)
 	}
 

--- a/pkg/ssh/ssh.go
+++ b/pkg/ssh/ssh.go
@@ -7,8 +7,6 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
-
-	"github.com/cli/safeexec"
 )
 
 type Translator struct {
@@ -57,7 +55,7 @@ func (t *Translator) resolve(hostname string) (string, error) {
 	if t.sshPath == "" && t.sshPathErr == nil {
 		lookPath := t.lookPath
 		if lookPath == nil {
-			lookPath = safeexec.LookPath
+			lookPath = exec.LookPath
 		}
 		t.sshPath, t.sshPathErr = lookPath("ssh")
 	}

--- a/pkg/ssh/ssh_test.go
+++ b/pkg/ssh/ssh_test.go
@@ -9,11 +9,10 @@ import (
 	"testing"
 
 	"github.com/MakeNowJust/heredoc"
-	"github.com/cli/safeexec"
 )
 
 func TestTranslator(t *testing.T) {
-	if _, err := safeexec.LookPath("ssh"); err != nil {
+	if _, err := exec.LookPath("ssh"); err != nil {
 		t.Skip("no ssh found on system")
 	}
 


### PR DESCRIPTION
The safeexec package was a workaround for a security issue in exec.LookPath on Windows, where the current working directory was searched before PATH entries. This was fixed in Go 1.19 (see golang/go#43724), making safeexec redundant.

Since go-gh requires Go 1.25, replace all safeexec.LookPath calls with exec.LookPath from the standard library.