### PR TITLE
Add `bearer_auth` support for extensions

### DIFF
--- a/pkg/api/client_options.go
+++ b/pkg/api/client_options.go
@@ -6,6 +6,8 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"slices"
+	"strings"
 	"time"
 
 	"github.com/cli/go-gh/v2/pkg/auth"
@@ -17,13 +19,6 @@ type ClientOptions struct {
 	// AuthToken is the authorization token that will be used
 	// to authenticate against API endpoints.
 	AuthToken string
-
-	// BearerAuth specifies whether to use Bearer token authentication
-	// instead of the default token authentication. When true, the
-	// Authorization header will use "Bearer" scheme instead of "token".
-	// Default is resolved from the GH_BEARER_AUTH environment variable
-	// or the bearer_auth config setting.
-	BearerAuth bool
 
 	// CacheDir is the directory to use for cached API requests.
 	// Default is the same directory that gh uses for caching.
@@ -110,20 +105,14 @@ func resolveOptions(opts ClientOptions) (ClientOptions, error) {
 	if opts.UnixDomainSocket == "" && cfg != nil {
 		opts.UnixDomainSocket, _ = cfg.Get([]string{"http_unix_socket"})
 	}
-	if !opts.BearerAuth {
-		opts.BearerAuth = resolveBearerAuth(cfg, opts.Host)
-	}
 	return opts, nil
 }
 
 // resolveBearerAuth checks the GH_BEARER_AUTH environment variable first,
 // then falls back to the bearer_auth config setting (host-scoped, then global).
 func resolveBearerAuth(cfg *config.Config, host string) bool {
-	if os.Getenv("GH_BEARER_AUTH") != "" {
+	if isTruthy(os.Getenv("GH_BEARER_AUTH")) {
 		return true
-	}
-	if cfg == nil {
-		return false
 	}
 	if val, err := cfg.Get([]string{"hosts", host, "bearer_auth"}); err == nil {
 		return val == "enabled"
@@ -132,4 +121,10 @@ func resolveBearerAuth(cfg *config.Config, host string) bool {
 		return val == "enabled"
 	}
 	return false
+}
+
+var falseyValues = []string{"", "0", "false", "no", "disabled", "off"}
+
+func isTruthy(val string) bool {
+	return !slices.Contains(falseyValues, strings.TrimSpace(strings.ToLower(val)))
 }

--- a/pkg/api/client_options.go
+++ b/pkg/api/client_options.go
@@ -114,6 +114,9 @@ func resolveBearerAuth(cfg *config.Config, host string) bool {
 	if isTruthy(os.Getenv("GH_BEARER_AUTH")) {
 		return true
 	}
+	if cfg == nil {
+		return false
+	}
 	if val, err := cfg.Get([]string{"hosts", host, "bearer_auth"}); err == nil {
 		return val == "enabled"
 	}

--- a/pkg/api/client_options.go
+++ b/pkg/api/client_options.go
@@ -110,14 +110,16 @@ func resolveOptions(opts ClientOptions) (ClientOptions, error) {
 
 // resolveBearerAuth checks the GH_BEARER_AUTH environment variable first,
 // then falls back to the bearer_auth config setting (host-scoped, then global).
-func resolveBearerAuth(cfg *config.Config, host string) bool {
-	if isTruthy(os.Getenv("GH_BEARER_AUTH")) {
-		return true
+func resolveBearerAuth(host string) bool {
+	if val, ok := os.LookupEnv("GH_BEARER_AUTH"); ok {
+		return isTruthy(val)
 	}
+	cfg, _ := config.Read(nil)
 	if cfg == nil {
 		return false
 	}
-	if val, err := cfg.Get([]string{"hosts", host, "bearer_auth"}); err == nil {
+	normalizedHost := auth.NormalizeHostname(host)
+	if val, err := cfg.Get([]string{"hosts", normalizedHost, "bearer_auth"}); err == nil {
 		return val == "enabled"
 	}
 	if val, err := cfg.Get([]string{"bearer_auth"}); err == nil {

--- a/pkg/api/client_options.go
+++ b/pkg/api/client_options.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/cli/go-gh/v2/pkg/auth"
@@ -16,6 +17,13 @@ type ClientOptions struct {
 	// AuthToken is the authorization token that will be used
 	// to authenticate against API endpoints.
 	AuthToken string
+
+	// BearerAuth specifies whether to use Bearer token authentication
+	// instead of the default token authentication. When true, the
+	// Authorization header will use "Bearer" scheme instead of "token".
+	// Default is resolved from the GH_BEARER_AUTH environment variable
+	// or the bearer_auth config setting.
+	BearerAuth bool
 
 	// CacheDir is the directory to use for cached API requests.
 	// Default is the same directory that gh uses for caching.
@@ -102,5 +110,26 @@ func resolveOptions(opts ClientOptions) (ClientOptions, error) {
 	if opts.UnixDomainSocket == "" && cfg != nil {
 		opts.UnixDomainSocket, _ = cfg.Get([]string{"http_unix_socket"})
 	}
+	if !opts.BearerAuth {
+		opts.BearerAuth = resolveBearerAuth(cfg, opts.Host)
+	}
 	return opts, nil
+}
+
+// resolveBearerAuth checks the GH_BEARER_AUTH environment variable first,
+// then falls back to the bearer_auth config setting (host-scoped, then global).
+func resolveBearerAuth(cfg *config.Config, host string) bool {
+	if os.Getenv("GH_BEARER_AUTH") != "" {
+		return true
+	}
+	if cfg == nil {
+		return false
+	}
+	if val, err := cfg.Get([]string{"hosts", host, "bearer_auth"}); err == nil {
+		return val == "enabled"
+	}
+	if val, err := cfg.Get([]string{"bearer_auth"}); err == nil {
+		return val == "enabled"
+	}
+	return false
 }

--- a/pkg/api/client_options_test.go
+++ b/pkg/api/client_options_test.go
@@ -185,8 +185,6 @@ func TestResolveBearerAuth(t *testing.T) {
 		cfg, _ := config.Read(nil)
 		assert.True(t, resolveBearerAuth(cfg, "github.com"))
 	})
-
-
 }
 
 func testConfig() string {

--- a/pkg/api/client_options_test.go
+++ b/pkg/api/client_options_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/cli/go-gh/v2/internal/testutils"
-	"github.com/cli/go-gh/v2/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -154,36 +153,42 @@ func TestOptionsNeedResolution(t *testing.T) {
 func TestResolveBearerAuth(t *testing.T) {
 	t.Run("returns false by default", func(t *testing.T) {
 		testutils.StubConfig(t, testConfig())
-		cfg, _ := config.Read(nil)
-		assert.False(t, resolveBearerAuth(cfg, "github.com"))
+		assert.False(t, resolveBearerAuth("github.com"))
 	})
 
 	t.Run("returns true when GH_BEARER_AUTH is truthy", func(t *testing.T) {
 		testutils.StubConfig(t, testConfig())
-		cfg, _ := config.Read(nil)
 		t.Setenv("GH_BEARER_AUTH", "1")
-		assert.True(t, resolveBearerAuth(cfg, "github.com"))
+		assert.True(t, resolveBearerAuth("github.com"))
 	})
 
 	t.Run("returns false when GH_BEARER_AUTH is falsey", func(t *testing.T) {
 		testutils.StubConfig(t, testConfig())
-		cfg, _ := config.Read(nil)
 		for _, val := range []string{"0", "false", "no", "disabled", "off"} {
 			t.Setenv("GH_BEARER_AUTH", val)
-			assert.False(t, resolveBearerAuth(cfg, "github.com"), "expected false for GH_BEARER_AUTH=%q", val)
+			assert.False(t, resolveBearerAuth("github.com"), "expected false for GH_BEARER_AUTH=%q", val)
 		}
+	})
+
+	t.Run("falsey env var overrides enabled config", func(t *testing.T) {
+		testutils.StubConfig(t, testConfigWithBearerAuth())
+		t.Setenv("GH_BEARER_AUTH", "0")
+		assert.False(t, resolveBearerAuth("github.com"))
 	})
 
 	t.Run("returns true when globally enabled in config", func(t *testing.T) {
 		testutils.StubConfig(t, testConfigWithBearerAuth())
-		cfg, _ := config.Read(nil)
-		assert.True(t, resolveBearerAuth(cfg, "github.com"))
+		assert.True(t, resolveBearerAuth("github.com"))
 	})
 
 	t.Run("returns true when enabled for host in config", func(t *testing.T) {
 		testutils.StubConfig(t, testConfigWithHostBearerAuth())
-		cfg, _ := config.Read(nil)
-		assert.True(t, resolveBearerAuth(cfg, "github.com"))
+		assert.True(t, resolveBearerAuth("github.com"))
+	})
+
+	t.Run("resolves host-scoped config with non-normalized host", func(t *testing.T) {
+		testutils.StubConfig(t, testConfigWithHostBearerAuth())
+		assert.True(t, resolveBearerAuth("api.github.com"))
 	})
 }
 

--- a/pkg/api/client_options_test.go
+++ b/pkg/api/client_options_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cli/go-gh/v2/internal/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestResolveOptions(t *testing.T) {
@@ -150,6 +151,44 @@ func TestOptionsNeedResolution(t *testing.T) {
 	}
 }
 
+func TestResolveBearerAuth(t *testing.T) {
+	t.Run("returns false by default", func(t *testing.T) {
+		testutils.StubConfig(t, testConfig())
+		opts, err := resolveOptions(ClientOptions{})
+		require.NoError(t, err)
+		assert.False(t, opts.BearerAuth)
+	})
+
+	t.Run("returns true when GH_BEARER_AUTH is set", func(t *testing.T) {
+		testutils.StubConfig(t, testConfig())
+		t.Setenv("GH_BEARER_AUTH", "1")
+		opts, err := resolveOptions(ClientOptions{})
+		require.NoError(t, err)
+		assert.True(t, opts.BearerAuth)
+	})
+
+	t.Run("returns true when globally enabled in config", func(t *testing.T) {
+		testutils.StubConfig(t, testConfigWithBearerAuth())
+		opts, err := resolveOptions(ClientOptions{})
+		require.NoError(t, err)
+		assert.True(t, opts.BearerAuth)
+	})
+
+	t.Run("returns true when enabled for host in config", func(t *testing.T) {
+		testutils.StubConfig(t, testConfigWithHostBearerAuth())
+		opts, err := resolveOptions(ClientOptions{})
+		require.NoError(t, err)
+		assert.True(t, opts.BearerAuth)
+	})
+
+	t.Run("honors consumer provided BearerAuth", func(t *testing.T) {
+		testutils.StubConfig(t, testConfig())
+		opts, err := resolveOptions(ClientOptions{BearerAuth: true})
+		require.NoError(t, err)
+		assert.True(t, opts.BearerAuth)
+	})
+}
+
 func testConfig() string {
 	return `
 hosts:
@@ -157,6 +196,28 @@ hosts:
     user: user1
     oauth_token: abc123
     git_protocol: ssh
+`
+}
+
+func testConfigWithBearerAuth() string {
+	return `
+bearer_auth: enabled
+hosts:
+  github.com:
+    user: user1
+    oauth_token: abc123
+    git_protocol: ssh
+`
+}
+
+func testConfigWithHostBearerAuth() string {
+	return `
+hosts:
+  github.com:
+    user: user1
+    oauth_token: abc123
+    git_protocol: ssh
+    bearer_auth: enabled
 `
 }
 

--- a/pkg/api/client_options_test.go
+++ b/pkg/api/client_options_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/cli/go-gh/v2/internal/testutils"
+	"github.com/cli/go-gh/v2/pkg/config"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestResolveOptions(t *testing.T) {
@@ -154,39 +154,39 @@ func TestOptionsNeedResolution(t *testing.T) {
 func TestResolveBearerAuth(t *testing.T) {
 	t.Run("returns false by default", func(t *testing.T) {
 		testutils.StubConfig(t, testConfig())
-		opts, err := resolveOptions(ClientOptions{})
-		require.NoError(t, err)
-		assert.False(t, opts.BearerAuth)
+		cfg, _ := config.Read(nil)
+		assert.False(t, resolveBearerAuth(cfg, "github.com"))
 	})
 
-	t.Run("returns true when GH_BEARER_AUTH is set", func(t *testing.T) {
+	t.Run("returns true when GH_BEARER_AUTH is truthy", func(t *testing.T) {
 		testutils.StubConfig(t, testConfig())
+		cfg, _ := config.Read(nil)
 		t.Setenv("GH_BEARER_AUTH", "1")
-		opts, err := resolveOptions(ClientOptions{})
-		require.NoError(t, err)
-		assert.True(t, opts.BearerAuth)
+		assert.True(t, resolveBearerAuth(cfg, "github.com"))
+	})
+
+	t.Run("returns false when GH_BEARER_AUTH is falsey", func(t *testing.T) {
+		testutils.StubConfig(t, testConfig())
+		cfg, _ := config.Read(nil)
+		for _, val := range []string{"0", "false", "no", "disabled", "off"} {
+			t.Setenv("GH_BEARER_AUTH", val)
+			assert.False(t, resolveBearerAuth(cfg, "github.com"), "expected false for GH_BEARER_AUTH=%q", val)
+		}
 	})
 
 	t.Run("returns true when globally enabled in config", func(t *testing.T) {
 		testutils.StubConfig(t, testConfigWithBearerAuth())
-		opts, err := resolveOptions(ClientOptions{})
-		require.NoError(t, err)
-		assert.True(t, opts.BearerAuth)
+		cfg, _ := config.Read(nil)
+		assert.True(t, resolveBearerAuth(cfg, "github.com"))
 	})
 
 	t.Run("returns true when enabled for host in config", func(t *testing.T) {
 		testutils.StubConfig(t, testConfigWithHostBearerAuth())
-		opts, err := resolveOptions(ClientOptions{})
-		require.NoError(t, err)
-		assert.True(t, opts.BearerAuth)
+		cfg, _ := config.Read(nil)
+		assert.True(t, resolveBearerAuth(cfg, "github.com"))
 	})
 
-	t.Run("honors consumer provided BearerAuth", func(t *testing.T) {
-		testutils.StubConfig(t, testConfig())
-		opts, err := resolveOptions(ClientOptions{BearerAuth: true})
-		require.NoError(t, err)
-		assert.True(t, opts.BearerAuth)
-	})
+
 }
 
 func testConfig() string {

--- a/pkg/api/http_client.go
+++ b/pkg/api/http_client.go
@@ -117,8 +117,7 @@ func NewHTTPClient(opts ClientOptions) (*http.Client, error) {
 		setDefaultHeaders(opts.Headers)
 	}
 
-	cfg, _ := config.Read(nil)
-	bearerAuth := resolveBearerAuth(cfg, opts.Host)
+	bearerAuth := resolveBearerAuth(opts.Host)
 	transport = newHeaderRoundTripper(opts.Host, opts.AuthToken, bearerAuth, opts.Headers, transport)
 
 	return &http.Client{Transport: transport, Timeout: opts.Timeout}, nil

--- a/pkg/api/http_client.go
+++ b/pkg/api/http_client.go
@@ -117,7 +117,6 @@ func NewHTTPClient(opts ClientOptions) (*http.Client, error) {
 		setDefaultHeaders(opts.Headers)
 	}
 
-	// Bearer auth is always resolved internally from env/config, never set by consumers.
 	cfg, _ := config.Read(nil)
 	bearerAuth := resolveBearerAuth(cfg, opts.Host)
 	transport = newHeaderRoundTripper(opts.Host, opts.AuthToken, bearerAuth, opts.Headers, transport)

--- a/pkg/api/http_client.go
+++ b/pkg/api/http_client.go
@@ -116,7 +116,7 @@ func NewHTTPClient(opts ClientOptions) (*http.Client, error) {
 	if !opts.SkipDefaultHeaders {
 		setDefaultHeaders(opts.Headers)
 	}
-	transport = newHeaderRoundTripper(opts.Host, opts.AuthToken, opts.Headers, transport)
+	transport = newHeaderRoundTripper(opts.Host, opts.AuthToken, opts.BearerAuth, opts.Headers, transport)
 
 	return &http.Client{Transport: transport, Timeout: opts.Timeout}, nil
 }
@@ -177,9 +177,13 @@ func setDefaultHeaders(headers map[string]string) {
 	}
 }
 
-func newHeaderRoundTripper(host string, authToken string, headers map[string]string, rt http.RoundTripper) http.RoundTripper {
+func newHeaderRoundTripper(host string, authToken string, bearerAuth bool, headers map[string]string, rt http.RoundTripper) http.RoundTripper {
 	if _, ok := headers[authorization]; !ok && authToken != "" {
-		headers[authorization] = fmt.Sprintf("token %s", authToken)
+		scheme := "token"
+		if bearerAuth {
+			scheme = "Bearer"
+		}
+		headers[authorization] = fmt.Sprintf("%s %s", scheme, authToken)
 	}
 	if len(headers) == 0 {
 		return rt

--- a/pkg/api/http_client.go
+++ b/pkg/api/http_client.go
@@ -116,7 +116,11 @@ func NewHTTPClient(opts ClientOptions) (*http.Client, error) {
 	if !opts.SkipDefaultHeaders {
 		setDefaultHeaders(opts.Headers)
 	}
-	transport = newHeaderRoundTripper(opts.Host, opts.AuthToken, opts.BearerAuth, opts.Headers, transport)
+
+	// Bearer auth is always resolved internally from env/config, never set by consumers.
+	cfg, _ := config.Read(nil)
+	bearerAuth := resolveBearerAuth(cfg, opts.Host)
+	transport = newHeaderRoundTripper(opts.Host, opts.AuthToken, bearerAuth, opts.Headers, transport)
 
 	return &http.Client{Transport: transport, Timeout: opts.Timeout}, nil
 }

--- a/pkg/api/http_client_test.go
+++ b/pkg/api/http_client_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cli/go-gh/v2/internal/testutils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/h2non/gock.v1"
 )
 
@@ -156,6 +157,32 @@ func TestNewHTTPClient(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewHTTPClientBearerAuth(t *testing.T) {
+	reflectHTTP := tripper{
+		roundTrip: func(req *http.Request) (*http.Response, error) {
+			header := req.Header.Clone()
+			return &http.Response{
+				StatusCode: 200,
+				Header:     header,
+				Body:       io.NopCloser(bytes.NewBufferString("{}")),
+			}, nil
+		},
+	}
+
+	opts := ClientOptions{
+		Host:         "test.com",
+		AuthToken:    "oauth_token",
+		BearerAuth:   true,
+		Transport:    reflectHTTP,
+		LogIgnoreEnv: true,
+	}
+	client, err := NewHTTPClient(opts)
+	require.NoError(t, err)
+	res, err := client.Get("https://test.com")
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer oauth_token", res.Header.Get(authorization))
 }
 
 type tripper struct {

--- a/pkg/api/http_client_test.go
+++ b/pkg/api/http_client_test.go
@@ -34,6 +34,8 @@ func TestHTTPClient(t *testing.T) {
 }
 
 func TestNewHTTPClient(t *testing.T) {
+	testutils.StubConfig(t, testConfig())
+
 	reflectHTTP := tripper{
 		roundTrip: func(req *http.Request) (*http.Response, error) {
 			header := req.Header.Clone()
@@ -160,6 +162,8 @@ func TestNewHTTPClient(t *testing.T) {
 }
 
 func TestNewHTTPClientBearerAuth(t *testing.T) {
+	testutils.StubConfig(t, testConfig())
+
 	reflectHTTP := tripper{
 		roundTrip: func(req *http.Request) (*http.Response, error) {
 			header := req.Header.Clone()

--- a/pkg/api/http_client_test.go
+++ b/pkg/api/http_client_test.go
@@ -171,10 +171,10 @@ func TestNewHTTPClientBearerAuth(t *testing.T) {
 		},
 	}
 
+	t.Setenv("GH_BEARER_AUTH", "1")
 	opts := ClientOptions{
 		Host:         "test.com",
 		AuthToken:    "oauth_token",
-		BearerAuth:   true,
 		Transport:    reflectHTTP,
 		LogIgnoreEnv: true,
 	}


### PR DESCRIPTION
## Summary

Adds Bearer token authentication support to `go-gh` so that extensions respect the `bearer_auth` config setting and `GH_BEARER_AUTH` environment variable.

When enabled, `Authorization: token <TOKEN>` becomes `Authorization: Bearer <TOKEN>`.

## Motivation

Companion to https://github.com/cli/cli/pull/13400

Resolves the extension side of https://github.com/cli/cli/issues/11727 — enterprise proxy setups that only accept standard `Authorization: Bearer` scheme need extensions to also use Bearer authentication.

## Usage

Extensions using `go-gh`'s `NewHTTPClient` will automatically respect the toggle when it is set in the shared config or environment variable. No code changes are needed in existing extensions.