### PR TITLE
api: treat application/octocat-stream as inspectable

### DIFF
--- a/pkg/api/http_client.go
+++ b/pkg/api/http_client.go
@@ -124,6 +124,9 @@ func NewHTTPClient(opts ClientOptions) (*http.Client, error) {
 func inspectableMIMEType(t string) bool {
 	return strings.HasPrefix(t, "text/") ||
 		strings.HasPrefix(t, "application/x-www-form-urlencoded") ||
+		// /octocat returns ASCII art tagged as application/octocat-stream.
+		// Treat it as inspectable so --verbose actually shows the response.
+		strings.HasPrefix(t, "application/octocat-stream") ||
 		jsonTypeRE.MatchString(t)
 }
 

--- a/pkg/api/http_client_test.go
+++ b/pkg/api/http_client_test.go
@@ -186,3 +186,24 @@ func printPendingMocks(mocks []gock.Mock) string {
 	}
 	return fmt.Sprintf("%d unmatched mocks: %s", len(paths), strings.Join(paths, ", "))
 }
+
+func TestInspectableMIMEType(t *testing.T) {
+	for _, tt := range []struct {
+		mime string
+		want bool
+	}{
+		{"text/plain", true},
+		{"text/html; charset=utf-8", true},
+		{"application/json", true},
+		{"application/vnd.github+json", true},
+		{"application/x-www-form-urlencoded", true},
+		// /octocat. See #210.
+		{"application/octocat-stream", true},
+		{"image/png", false},
+		{"application/octet-stream", false},
+	} {
+		if got := inspectableMIMEType(tt.mime); got != tt.want {
+			t.Errorf("inspectableMIMEType(%q) = %v, want %v", tt.mime, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #210.

`/octocat` returns ASCII art tagged with this non-standard content type, and httpretty was filtering it out so `gh api --verbose /octocat` showed empty response bodies. Treat it as inspectable like the other text-y types we already pass through.