### PR TITLE
Set `persist-credentials: false` on checkout steps

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Setup Go
         if: matrix.language == 'go'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Go
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0


### PR DESCRIPTION
## Summary

Sets `persist-credentials: false` on every `actions/checkout` step across our workflows. By default, `actions/checkout` persists the `GITHUB_TOKEN` on disk so that subsequent git operations are authenticated; when downstream steps don't need that, opting out removes an unnecessary credential-leak surface. This is the [`artipacked`](https://docs.zizmor.sh/audits/#artipacked) audit in [zizmor](https://github.com/zizmorcore/zizmor).

### Where the token actually lives (FYI)

- **`actions/checkout@v4`** (what we use today): the token is written into the repo's `.git/config` as an `http.https://github.com/.extraheader` basic-auth value. So if any later step uploads the workspace (including `.git/`) as an artifact, the token rides along.
- **`actions/checkout@v5`+ / `v6`** ([#2286 "Persist creds to a separate file"](https://github.com/actions/checkout/pull/2286)): the auth header is written to `$RUNNER_TEMP/git-credentials-<uuid>.config` and `.git/config` only contains an `includeIf.gitdir:<repo>.path = <that file>` pointer. The credential is no longer captured by a `.git/`-inclusive artifact upload, but it still persists on disk in `RUNNER_TEMP` until the post-job cleanup removes it.

`persist-credentials: false` skips writing the credential anywhere in either version.

## Changes

- `.github/workflows/codeql-analysis.yml`
- `.github/workflows/lint.yml`
- `.github/workflows/test.yml`

## Safety

None of the affected workflows perform authenticated git operations after checkout:

| Workflow | Post-checkout work | Needs persisted token? |
|---|---|---|
| `codeql-analysis.yml` | `github/codeql-action/init` + `analyze` | No — CodeQL uses its own token via env, not git config |
| `lint.yml` | `setup-go`, `go mod tidy`, `git diff --exit-code go.mod`, `golangci-lint-action` | No — `git diff` is purely local; all module deps are public (no `GOPRIVATE`) |
| `test.yml` | `setup-go`, `go test -v ./...` | No — public module deps only |

No `git push`, no submodules, no private module fetches, no `gh` calls that rely on the persisted git credential.

## Verification

`zizmor` reports clean after the change:

```
No findings to report. Good job! (8 suppressed)
```
