### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: "daily"
+  cooldown:
+    default-days: 5
+  ignore:
+    - dependency-name: "*"
+      update-types:
+        - version-update:semver-major
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "daily"
+  cooldown:
+    default-days: 5


### PR DESCRIPTION
## Summary

Adds a `.github/dependabot.yml` mirroring [`cli/cli`'s configuration](https://github.com/cli/cli/blob/trunk/.github/dependabot.yml), with one addition: a 5-day cooldown on new releases.

## Config

- **`gomod`** — daily checks, semver-major bumps ignored (matches `cli/cli`)
- **`github-actions`** — daily checks
- **`cooldown.default-days: 5`** on both — Dependabot waits 5 days after a release before opening a PR for it. Gives the ecosystem time to surface obvious regressions before we adopt a new version, and avoids churning PRs for releases that get yanked or quickly superseded.

## Why now

We just landed a [zizmor hardening pass](https://github.com/cli/go-gh/pull/225) on these same workflows. Dependabot will keep the action pins moving forward so we don't drift back into stale, unaudited versions, and will do the same for Go module deps.

## References

- Dependabot [`cooldown` docs](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown) — `default-days` is supported for both `gomod` and `github-actions`.
