### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @cli/code-reviewers


### PR DESCRIPTION
## Summary

Adds a `.github/CODEOWNERS` so that PRs in `cli/go-gh` automatically request review from `@cli/code-reviewers`, matching the pattern used in [`cli/cli`](https://github.com/cli/cli/blob/trunk/.github/CODEOWNERS).