### PR TITLE
Reduce dependabot cooldown to 3 days

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
   schedule:
     interval: "daily"
   cooldown:
-    default-days: 5
+    default-days: 3
   ignore:
     - dependency-name: "*"
       update-types:
@@ -15,4 +15,4 @@ updates:
   schedule:
       interval: "daily"
   cooldown:
-    default-days: 5
+    default-days: 3


### PR DESCRIPTION
Reduces the dependabot `cooldown.default-days` from 5 to 3 to align cooldown duration across cli/* repositories.