### PR TITLE
SHA pin first-party GitHub Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,21 +25,21 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Go
         if: matrix.language == 'go'
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: "go.mod"
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.35.5
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.35.5
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,10 +8,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: go.mod
 


### PR DESCRIPTION
Part of the org-wide rollout following cli/cli#13491. See cli/cli#13490 for full rationale.

## What

Replaces every `actions/*` and `github/*` `uses:` reference in `.github/workflows/*.yml` with the equivalent commit SHA, preserving the human-readable version in a trailing comment. Matches the convention already used for third-party action pins.

Unique pins introduced:

| Action | Pinned to |
| --- | --- |
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2` |
| `actions/setup-go` | `4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0` |
| `github/codeql-action/init` | `7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0` |
| `github/codeql-action/analyze` | `7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0` |

## Why

With the 3-day dependabot cooldown configured for `github-actions`, version-tag references give no real benefit (dependabot still opens PRs on patch releases) while leaving us exposed to tag-mutation supply chain attacks on first-party namespaces. SHA pinning is the more consistent and defensible posture.

## Verification

- All workflow YAML still parses.
- No first-party `@vN` refs remain (`grep -E 'uses: (actions|github)/[^@]+@v[0-9]' .github/workflows/*.yml` returns empty).
- Dependabot natively parses `<sha> # vX.Y.Z` pins and will bump both the SHA and the comment on the next patch release.

Opened as a **draft** for review; mark ready when checks pass.