### PR TITLE
Keep full precision for non-integer numbers in jq output

### DIFF
--- a/pkg/jq/jq.go
+++ b/pkg/jq/jq.go
@@ -104,7 +104,7 @@ func jsonScalarToString(input interface{}) (string, error) {
 		if math.Trunc(tt) == tt {
 			return strconv.FormatFloat(tt, 'f', 0, 64), nil
 		} else {
-			return strconv.FormatFloat(tt, 'f', 2, 64), nil
+			return strconv.FormatFloat(tt, 'f', -1, 64), nil
 		}
 	case nil:
 		return "", nil

--- a/pkg/jq/jq_test.go
+++ b/pkg/jq/jq_test.go
@@ -173,6 +173,16 @@ func TestEvaluateFormatted(t *testing.T) {
 				"\x1b[1;38m}\x1b[m\n",
 		},
 		{
+			name: "non-integer numbers keep full precision",
+			args: args{
+				json:     strings.NewReader(`{"pi": 3.14159, "small": 0.001, "big": 123456.789}`),
+				expr:     `.pi, .small, .big`,
+				indent:   "",
+				colorize: false,
+			},
+			wantW: "3.14159\n0.001\n123456.789\n",
+		},
+		{
 			name: "halt function",
 			args: args{
 				json: strings.NewReader("{}"),


### PR DESCRIPTION
`jq.Evaluate` rounds non-integer numbers to two decimal places, so the output loses precision and can even turn a nonzero value into zero.

For input `{"pi": 3.14159, "small": 0.001, "big": 123456.789}`, evaluating `.pi, .small, .big` prints:

```
3.14
0.00
123456.79
```

`jsonScalarToString` formats non-integer `float64` values with `strconv.FormatFloat(tt, 'f', 2, 64)`. The package doc says scalars are written "similar to how jq --raw works", but `jq` prints `3.14159`, `0.001`, and `123456.789`. The `0.001 -> 0.00` case is the worst one, since a nonzero number renders as zero.

The non-integer branch now uses precision `-1`, the shortest string that round-trips the `float64`, so the three values above print exactly as `jq` does. The integer-valued branch is unchanged, so whole numbers still print without a trailing `.0`.

Added a case to `TestEvaluateFormatted` covering `3.14159`, `0.001`, and `123456.789`. It fails on the current code and passes with the change. `go test ./...`, `go vet`, and `gofmt -l` are clean.
