### PR TITLE
Group CodeQL Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
       interval: "daily"
   cooldown:
     default-days: 3
+  groups:
+    codeql-actions:
+      patterns:
+        - "github/codeql-action/*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-      interval: "daily"
+    interval: "daily"
   cooldown:
     default-days: 3
   groups:


### PR DESCRIPTION
## Summary

This groups `github/codeql-action/*` GitHub Actions update into one Dependabot pull request. We do this because sometimes the codeql-actions depend on each other and then two independent PRs break.
