### PR TITLE
Let clients configure a redirect policy

### DIFF
--- a/pkg/api/client_options.go
+++ b/pkg/api/client_options.go
@@ -25,6 +25,16 @@ type ClientOptions struct {
 	// Default is 24 hours.
 	CacheTTL time.Duration
 
+	// CheckRedirect specifies the policy for handling redirects, matching the
+	// field of the same name on http.Client. If nil, the default policy of
+	// following up to 10 redirects is used.
+	//
+	// This matters for requests where following a redirect silently changes
+	// the meaning of the request. Go's default policy converts a DELETE into a
+	// GET when it follows a 301, so a caller deleting a renamed resource can
+	// receive a success response having deleted nothing.
+	CheckRedirect func(*http.Request, []*http.Request) error
+
 	// EnableCache specifies if API requests will be cached or not.
 	// Default is no caching.
 	EnableCache bool

--- a/pkg/api/http_client.go
+++ b/pkg/api/http_client.go
@@ -118,7 +118,7 @@ func NewHTTPClient(opts ClientOptions) (*http.Client, error) {
 	}
 	transport = newHeaderRoundTripper(opts.Host, opts.AuthToken, opts.Headers, transport)
 
-	return &http.Client{Transport: transport, Timeout: opts.Timeout}, nil
+	return &http.Client{Transport: transport, Timeout: opts.Timeout, CheckRedirect: opts.CheckRedirect}, nil
 }
 
 func inspectableMIMEType(t string) bool {

--- a/pkg/api/http_client_test.go
+++ b/pkg/api/http_client_test.go
@@ -158,6 +158,74 @@ func TestNewHTTPClient(t *testing.T) {
 	}
 }
 
+func TestNewHTTPClientCheckRedirect(t *testing.T) {
+	// Redirect handling belongs to http.Client rather than the transport, so a
+	// stub transport still exercises the real policy: the client asks it for the
+	// redirected request only if the policy allows the redirect.
+	newRecordingTransport := func(methods *[]string) tripper {
+		return tripper{
+			roundTrip: func(req *http.Request) (*http.Response, error) {
+				*methods = append(*methods, req.Method)
+				if len(*methods) == 1 {
+					return &http.Response{
+						StatusCode: http.StatusMovedPermanently,
+						Header:     http.Header{"Location": []string{"https://api.github.com/repos/OWNER/NEW"}},
+						Body:       io.NopCloser(bytes.NewBufferString("")),
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusNoContent,
+					Body:       io.NopCloser(bytes.NewBufferString("")),
+				}, nil
+			},
+		}
+	}
+
+	t.Run("follows redirects by default, downgrading DELETE to GET", func(t *testing.T) {
+		var methods []string
+		client, err := NewHTTPClient(ClientOptions{
+			Host:      "github.com",
+			AuthToken: "oauth_token",
+			Transport: newRecordingTransport(&methods),
+		})
+		assert.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodDelete, "https://api.github.com/repos/OWNER/OLD", nil)
+		assert.NoError(t, err)
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+
+		// This is the behaviour that makes the option necessary. Go turns the
+		// DELETE into a GET when it follows the redirect, so the caller is told
+		// the request succeeded while nothing was deleted.
+		assert.Equal(t, []string{http.MethodDelete, http.MethodGet}, methods)
+		assert.Equal(t, http.StatusNoContent, res.StatusCode)
+	})
+
+	t.Run("honours a CheckRedirect that stops at the redirect", func(t *testing.T) {
+		var methods []string
+		client, err := NewHTTPClient(ClientOptions{
+			Host:      "github.com",
+			AuthToken: "oauth_token",
+			Transport: newRecordingTransport(&methods),
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		})
+		assert.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodDelete, "https://api.github.com/repos/OWNER/OLD", nil)
+		assert.NoError(t, err)
+		res, err := client.Do(req)
+		assert.NoError(t, err)
+		defer res.Body.Close()
+
+		assert.Equal(t, []string{http.MethodDelete}, methods)
+		assert.Equal(t, http.StatusMovedPermanently, res.StatusCode)
+	})
+}
+
 type tripper struct {
 	roundTrip func(*http.Request) (*http.Response, error)
 }


### PR DESCRIPTION
`NewHTTPClient` builds an `http.Client` from `ClientOptions` but never sets
`CheckRedirect`, so a caller has no way to control redirect handling and always
gets Go's default policy.

That default is not always what a caller wants. Go converts a `DELETE` into a
`GET` when it follows a 301, so a client deleting a resource that has been
renamed receives a success response having deleted nothing.

This adds a `CheckRedirect` field to `ClientOptions` and threads it through, in
the same shape as `http.Client`'s field of the same name. Behaviour is unchanged
when it is nil.

### Why now

cli/cli is migrating its remaining raw `httpClient.Do` call sites onto its
`api.Client`, so that all API traffic honours the per-host `api_host` config
added in #275. `gh repo delete` was the one site that could not migrate: it
needs this policy, and because go-gh discarded it, the command had to build its
own client and hold an absolute `api.github.com` URL, which meant it silently
ignored `api_host`.

With this change it migrates, and an end-to-end test that routes every request
through a gateway with `api.github.com` blackholed passes in full. That test is
what surfaced this: `gh repo delete` was the last command still reaching
GitHub directly.

Together with #275, this is everything go-gh needs for that work. Draft because
#275 should land first.

### Testing

`TestNewHTTPClientCheckRedirect` covers both the default policy and a custom one
that stops at the redirect. It uses the package's existing `tripper` stub;
redirect policy lives on `http.Client` above the transport, so a stubbed
transport still exercises the real policy.

Verified the test detects the bug: reverting the one-line change to
`NewHTTPClient` fails it with `expected: 301, actual: 204`.
